### PR TITLE
Add support for getter(t) type annotation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -222,6 +222,8 @@ const print = (path, options, print) => {
         return group(["[", indent([softline, print("value")]), softline, "]"]);
       case "ref":
         return group(["ref", "(", print("value"), ")"]);
+      case "getter":
+        return group(["getter", "(", print("value"), ")"]);
       case "json_object":
         return [
           "[",


### PR DESCRIPTION
Adds formatting support for the new `getter(t)` type annotation syntax introduced in savonet/liquidsoap#5078.

The OCaml parser emits `{typ: "getter", ...}` in the JSON AST for getter type annotations. This PR adds the corresponding case to `printTypeAnnotation` in `index.js`, formatting it as `getter(<inner type>)` — consistent with how `ref(t)` is handled.

Depends on savonet/liquidsoap#5078 being merged and the opam package updated before a release.