### PR TITLE
cli: add --version, --help, --stdin-filepath, --dump-ast; stdlib formatting CI

### DIFF
--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -6,6 +6,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -22,6 +22,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
+          version: 10
           run_install: true
 
       - name: Check that stdlib files are formatted

--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -2,6 +2,8 @@ name: Check formatting
 
 on:
   push:
+    branches:
+      - main
   pull_request:
 
 jobs:

--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -1,0 +1,21 @@
+name: Check formatting
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: npm
+
+      - run: npm ci
+
+      - name: Check that stdlib files are formatted
+        run: node src/cli.js --check 'tests/liq/**/*.liq'

--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -25,5 +25,7 @@ jobs:
           version: 10
           run_install: true
 
+      - run: pnpm dev:prepare
+
       - name: Check that stdlib files are formatted
         run: node src/cli.js --check 'tests/liq/**/*.liq'

--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -13,9 +13,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: lts/*
-          cache: npm
 
-      - run: npm ci
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: true
 
       - name: Check that stdlib files are formatted
         run: node src/cli.js --check 'tests/liq/**/*.liq'

--- a/README.md
+++ b/README.md
@@ -11,18 +11,44 @@ The `liquidsoap-prettier` command-line utility should be installed with this
 package and should be available following the usual node package binary
 conventions.
 
-It works as follows:
+Format one or more files in place:
 
 ```shell
-$ liquidsoap-prettier [-w|--write] path/to/file.liq "path/with/glob/pattern/**/*.liq"
+$ liquidsoap-prettier -w path/to/file.liq "path/with/glob/pattern/**/*.liq"
 ```
 
-You can also simply check the script without formatting it:
+Print formatted output to stdout (single file only):
+
 ```shell
-$ liquidsoap-prettier [-c|--check] path/to/file.liq "path/with/glob/pattern/**/*.liq"
+$ liquidsoap-prettier path/to/file.liq
 ```
 
-The program returns with exit code `0` when the script is already pretty-printed and `2` otherwise.
+Read from stdin and write to stdout:
+
+```shell
+$ cat path/to/file.liq | liquidsoap-prettier --stdin-filepath file.liq
+```
+
+Check whether files are already formatted (useful in CI):
+
+```shell
+$ liquidsoap-prettier -c path/to/file.liq "path/with/glob/pattern/**/*.liq"
+```
+
+Returns exit code `0` when all files are already formatted, `2` otherwise.
+
+Dump the parsed AST as JSON (useful when debugging the printer):
+
+```shell
+$ liquidsoap-prettier --dump-ast path/to/file.liq
+```
+
+Print the version or show all options:
+
+```shell
+$ liquidsoap-prettier --version
+$ liquidsoap-prettier --help
+```
 
 ### Prettier plugin
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -5,38 +5,130 @@ import prettier from "prettier";
 import fs from "node:fs";
 import { glob } from "glob";
 import BluebirdPromise from "bluebird";
+import { createRequire } from "node:module";
 import * as prettierPluginLiquidsoap from "./index.js";
+
+const require = createRequire(import.meta.url);
+const { version } = require("../package.json");
+
+const HELP = `\
+Usage: liquidsoap-prettier [options] <file> [<file> ...]
+       liquidsoap-prettier [options] --stdin-filepath <name>
+
+Format Liquidsoap (.liq) files.
+
+Arguments:
+  <file>                   One or more files or glob patterns to format.
+
+Options:
+  -w, --write              Write formatted output back to each file in place.
+  -c, --check              Check if files are already formatted (exit 2 if not).
+      --print-width        Maximum line width (default: 80).
+      --stdin-filepath     Read from stdin; use <name> in error messages.
+      --dump-ast           Parse and dump the AST as JSON (for debugging).
+  -v, --version            Print the version and exit.
+  -h, --help               Show this help message and exit.
+
+Examples:
+  liquidsoap-prettier script.liq               # print formatted output to stdout
+  liquidsoap-prettier -w script.liq            # format file in place
+  liquidsoap-prettier -w '**/*.liq'            # format all .liq files in place
+  liquidsoap-prettier -c '**/*.liq'            # check formatting of all .liq files
+  liquidsoap-prettier -c script.liq            # check formatting (CI mode)
+  cat script.liq | liquidsoap-prettier --stdin-filepath script.liq
+  liquidsoap-prettier --dump-ast script.liq    # dump parsed AST as JSON
+`;
+
+const readStdin = () =>
+  new Promise((resolve, reject) => {
+    let data = "";
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (chunk) => (data += chunk));
+    process.stdin.on("end", () => resolve(data));
+    process.stdin.on("error", reject);
+  });
 
 const run = async () => {
   try {
     const {
-      _: [filename],
+      _: patterns,
       write,
       w,
       check,
       c,
+      version: showVersion,
+      v,
+      help,
+      h,
       "print-width": printWidth = 80,
+      "stdin-filepath": stdinFilepath,
+      "dump-ast": dumpAst,
     } = parseArgs(process.argv.slice(2), {
-      boolean: ["w", "write", "c", "check"],
+      boolean: ["w", "write", "c", "check", "v", "version", "h", "help", "dump-ast"],
+      string: ["stdin-filepath"],
       number: ["print-width"],
     });
 
-    if (!filename) {
+    if (help || h) {
+      process.stdout.write(HELP);
+      process.exit(0);
+    }
+
+    if (showVersion || v) {
+      console.log(version);
+      process.exit(0);
+    }
+
+    if (stdinFilepath) {
+      if (write || w) {
+        console.error("--write cannot be used with --stdin-filepath");
+        process.exit(1);
+      }
+      const code = await readStdin();
+      try {
+        if (dumpAst) {
+          const ast = prettierPluginLiquidsoap.parsers.liquidsoap.parse(code);
+          process.stdout.write(JSON.stringify(ast, null, 2) + "\n");
+        } else if (check || c) {
+          const isFormatted = await prettier.check(code, {
+            parser: "liquidsoap",
+            plugins: [prettierPluginLiquidsoap],
+            printWidth,
+          });
+          process.exit(isFormatted ? 0 : 2);
+        } else {
+          const formattedCode = await prettier.format(code, {
+            parser: "liquidsoap",
+            plugins: [prettierPluginLiquidsoap],
+            printWidth,
+          });
+          process.stdout.write(formattedCode);
+        }
+      } catch (err) {
+        console.error(`Error while processing ${stdinFilepath}: ${err}`);
+        process.exit(1);
+      }
+      process.exit(0);
+    }
+
+    if (patterns.length === 0) {
       console.error("No filename passed!");
       process.exit(1);
     }
 
-    const files = await glob(filename);
+    const files = (
+      await BluebirdPromise.map(patterns, (pattern) => glob(pattern))
+    ).flat();
 
-    if (files.length > 1 && !w && !write) {
+    if (files.length > 1 && !w && !write && !dumpAst && !c && !check) {
       console.error(
-        "-w|--write must be used when formatting more than one file at a time!",
+        "-w|--write or -c|--check must be used when passing more than one file!",
       );
       process.exit(1);
     }
 
     if (files.length === 0) {
-      console.error("No file passed!");
+      console.error("No file found matching the given pattern(s)!");
       process.exit(1);
     }
 
@@ -51,7 +143,10 @@ const run = async () => {
       const code = "" + fs.readFileSync(file);
 
       try {
-        if (check || c) {
+        if (dumpAst) {
+          const ast = prettierPluginLiquidsoap.parsers.liquidsoap.parse(code);
+          process.stdout.write(JSON.stringify(ast, null, 2) + "\n");
+        } else if (check || c) {
           const isFormatted = await prettier.check(code, {
             parser: "liquidsoap",
             plugins: [prettierPluginLiquidsoap],
@@ -66,7 +161,7 @@ const run = async () => {
           });
 
           if (write || w) {
-            console.log(`Writting formatted ${file}`);
+            console.log(`Writing formatted ${file}`);
             fs.writeFileSync(file, formattedCode);
           } else {
             process.stdout.write(formattedCode);

--- a/tests/liq/audio.liq
+++ b/tests/liq/audio.liq
@@ -1,0 +1,460 @@
+audio = ()
+let audio.encode = ()
+
+# Encode audio track to pcm_s16
+# @category Source / Audio processing
+def audio.encode.pcm_s16(~id=null("audio.encode.pcm_s16"), s) =
+  let {audio, ...tracks} = source.tracks(s)
+  source(id=id, tracks.{audio = track.encode.audio.pcm_s16(audio)})
+end
+
+# Encode audio track to pcm_f32
+# @category Source / Audio processing
+def audio.encode.pcm_f32(~id=null("audio.encode.pcm_f32"), s) =
+  let {audio, ...tracks} = source.tracks(s)
+  source(id=id, tracks.{audio = track.encode.audio.pcm_f32(audio)})
+end
+
+let audio.decode = ()
+
+# Decode audio track to pcm_s16
+# @category Source / Audio processing
+def audio.decode.pcm_s16(~id=null("audio.decode.pcm_s16"), s) =
+  let {audio, ...tracks} = source.tracks(s)
+  source(id=id, tracks.{audio = track.decode.audio.pcm_s16(audio)})
+end
+
+# Decode audio track to pcm_f32
+# @category Source / Audio processing
+def audio.decode.pcm_f32(~id=null("audio.decode.pcm_f32"), s) =
+  let {audio, ...tracks} = source.tracks(s)
+  source(id=id, tracks.{audio = track.decode.audio.pcm_f32(audio)})
+end
+
+# Samplerate for audio.
+# @category Settings
+def audio.samplerate =
+  settings.frame.audio.samplerate
+end
+
+# Channels for audio.
+# @category Settings
+def audio.channels =
+  settings.frame.audio.channels
+end
+
+# Multiply the amplitude of the signal.
+# @category Source / Audio processing
+# @param f Multiplicative factor.
+# @argsof track.audio.amplify
+def amplify(~id=null("amplify"), %argsof(track.audio.amplify[!id]), f, s) =
+  tracks = source.tracks(s)
+  source(
+    id=id,
+    tracks.{
+      audio =
+        track.audio.amplify(
+          id=null("track.audio.amplify"),
+          %argsof(track.audio.amplify[!id]),
+          f,
+          tracks.audio
+        )
+    }
+  )
+end
+
+# Clip samples, i.e. ensure that all values are between
+# `-1` and `1`: values lower than `-1` become `-1` and
+# values higher than `1` become `1`. `nan` values become `0`.
+# @category Source / Audio processing
+# @argsof track.audio.clip
+def clip(~id=null("clip"), %argsof(track.audio.clip[!id]), s) =
+  tracks = source.tracks(s)
+  source(
+    id=id,
+    tracks.{audio = track.audio.clip(%argsof(track.audio.clip), tracks.audio)}
+  )
+end
+
+lufs_builtin = lufs
+
+# Normalization the volume of a stream (this is also called _automatic gain
+# control_). Dynamic normalization of the signal is sometimes the only option
+# (for instance, for live sources), and can make a listening experience much
+# nicer. However, its dynamic aspect implies some limitations which can go as
+# far as creating saturation in some extreme cases. If possible, consider using
+# some track-based normalization techniques such as those based on
+# ReplayGain. The implementation of Liquidsoap < 2.0 was renamed to
+# `normalize.old`.
+# @category Source / Audio processing
+# @param ~id Force the value of the source ID.
+# @param ~gain_max Maximal gain value (dB).
+# @param ~gain_min Minimal gain value (dB).
+# @param ~down Characteristic time to go down.
+# @param ~up Characteristic time to go up.
+# @param ~lookahead How much time to look ahead of the signal (second). Setting a positive value delays the output by the corresponding amount of time.
+# @param ~lufs Use LUFS instead of RMS to compute intensity.
+# @param ~target Desired RMS (dB).
+# @param ~threshold Minimal RMS for activaing gain control (dB).
+# @param ~window Duration of the window used to compute the current RMS power (second).
+# @param ~enabled Whether normalization is enabled or not.
+# @param ~debug How often to print debug messages, in seconds, useful to finetune the parameters. You should set `set("log.level", 5)` to see them.
+# @param s Source to normalize.
+# @method gain Current amplification coefficient (in linear scale).
+# @method target_gain Current target amplification coefficient (in linear scale).
+# @method rms Current rms (in linear scale).
+def replaces normalize(
+  ~id=null,
+  ~target=getter(-13.),
+  ~up=getter(10.),
+  ~down=getter(.1),
+  ~gain_min=-12.,
+  ~gain_max=12.,
+  ~lufs=false,
+  ~lookahead=getter(0.),
+  ~window=getter(.5),
+  ~threshold=getter(-40.),
+  ~track_sensitive=true,
+  ~enabled=getter(true),
+  ~debug=null,
+  s
+) =
+  let (s, rms) =
+    if
+      lufs
+    then
+      s = lufs_builtin(id=id, window=window, s)
+      (s, {lin_of_dB(s.lufs())})
+    else
+      s = rms.smooth(id=id, duration=window, s)
+      (s, s.rms)
+    end
+
+  v = ref(1.)
+  frame = frame.duration()
+  gain_min = lin_of_dB(gain_min)
+  gain_max = lin_of_dB(gain_max)
+
+  def update() =
+    if
+      not (getter.get(enabled))
+    then
+      v := 1.
+    else
+      target = lin_of_dB(getter.get(target))
+      threshold = lin_of_dB(getter.get(threshold))
+      rms = rms()
+      if
+        rms >= threshold
+      then
+        if
+          v() * rms <= target
+        then
+          up = 1. - exp(0. - frame / getter.get(up))
+          v := v() + up * ((target / rms) - v())
+        else
+          down = 1. - exp(0. - frame / getter.get(down))
+          v := v() + down * ((target / rms) - v())
+        end
+
+        v := max(gain_min, min(gain_max, v()))
+      end
+    end
+  end
+
+  def target_gain() =
+    lin_of_dB(getter.get(target)) / rms()
+  end
+
+  s =
+    if
+      null.defined(debug)
+    then
+      source.run(
+        s,
+        every=null.get(debug),
+        {
+          log.debug(
+            "rms: #{rms()} / #{lin_of_dB(getter.get(target))}\tgain: #{v()} / #{
+              target_gain()
+            }"
+          )
+        }
+      )
+    else
+      s
+    end
+
+  s = source.methods(s)
+  s.on_frame(synchronous=true, update)
+  if track_sensitive then s.on_track(synchronous=true, fun (_) -> v := 1.) end
+  amplify(id=id, {v()}, delay_line(lookahead, s)).{
+    rms = rms,
+    gain = {v()},
+    target_gain = target_gain
+  }
+end
+
+# Swap two channels of a stereo source.
+# @category Source / Conversion
+def swap(id=null("swap"), s) =
+  tracks = source.tracks(s)
+  source(id=id, tracks.{audio = track.audio.swap(tracks.audio)})
+end
+
+# Produce mono audio by taking the mean of all audio channels.
+# @category Source / Conversion
+# @argsof track.audio.mean
+def mean(~id=null("mean"), %argsof(track.audio.mean[!id]), s) =
+  tracks = source.tracks(s)
+  source(
+    id=id,
+    tracks.{audio = track.audio.mean(%argsof(track.audio.mean), tracks.audio)}
+  )
+end
+
+# Convert any pcm audio source into a stereo source.
+# @category Source / Conversion
+def stereo(~id=null("stereo"), s) =
+  tracks = source.tracks(s)
+  source(id=id, tracks.{audio = track.audio.stereo(tracks.audio)})
+end
+
+# Extract the left channel of a stereo track
+# @category Source / Conversion
+# @param t Track to extract from
+def track.audio.stereo.left(~id=null("track.audio.stereo.left"), t) =
+  track.audio.amplify(
+    id=id,
+    override=null,
+    2.,
+    track.audio.mean(track.audio.stereo.pan(-1., t))
+  )
+end
+
+# Extract the left channel of a stereo source
+# @category Source / Conversion
+# @param s Source to extract from
+def stereo.left(~id=null("stereo.left"), s) =
+  tracks = source.tracks(s)
+  source(id=id, tracks.{audio = track.audio.stereo.left(tracks.audio)})
+end
+
+# Extract the right channel of a stereo track
+# @category Source / Conversion
+# @param s Track to extract from
+def track.audio.stereo.right(~id=null("track.audio.stereo.right"), t) =
+  track.audio.amplify(
+    id=id,
+    override=null,
+    2.,
+    track.audio.mean(track.audio.stereo.pan(1., t))
+  )
+end
+
+# Extract the right channel of a stereo source
+# @category Source / Conversion
+# @param s Source to extract from
+def stereo.right(~id=null("stereo.right"), s) =
+  tracks = source.tracks(s)
+  source(id=id, tracks.{audio = track.audio.stereo.right(tracks.audio)})
+end
+
+# Spacializer which allows controlling the width of the signal.
+# @category Source / Audio processing
+# @param w Width of the signal (-1: mono, 0.: original, 1.: wide stereo).
+def stereo.width(~id=null("stereo.width"), w=getter(0.), (s:source)) =
+  tracks = source.tracks(s)
+  source(id=id, tracks.{audio = track.audio.stereo.width(w, tracks.audio)})
+end
+
+# Pan a stereo sound.
+# @category Source / Audio processing
+# @argsof track.audio.stereo.pan
+# @param pan Pan value. Should be between `-1` (left side) and `1` (right side).
+def stereo.pan(
+  ~id=null("stereo.pan"),
+  %argsof(track.audio.stereo.pan[!id]),
+  pan,
+  (s:source)
+) =
+  tracks = source.tracks(s)
+  source(
+    id=id,
+    tracks.{
+      audio =
+        track.audio.stereo.pan(
+          %argsof(track.audio.stereo.pan),
+          pan,
+          tracks.audio
+        )
+    }
+  )
+end
+
+# Slow down or accelerate an audio stream by stretching (sounds lower) or squeezing it (sounds higher).
+# @category Source / Audio processing
+# @argsof track.audio.stretch
+def stretch(
+  ~id=null("stretch"),
+  %argsof(track.audio.stretch[!id]),
+  (s:source)
+) =
+  tracks = source.tracks(s)
+  source.audio(
+    id=id,
+    track.audio.stretch(%argsof(track.audio.stretch), tracks.audio)
+  )
+end
+
+let stereo.ms = ()
+
+# Decode mid+side stereo (M/S) to left+right stereo.
+# @category Source / Audio processing
+# @argsof track.audio.stereo.ms.decode
+def stereo.ms.decode(
+  ~id=null("stereo.ms.decode"),
+  %argsof(track.audio.stereo.ms.decode[!id]),
+  (s:source)
+) =
+  tracks = source.tracks(s)
+  source(
+    id=id,
+    tracks.{
+      audio =
+        track.audio.stereo.ms.decode(
+          %argsof(track.audio.stereo.ms.decode),
+          tracks.audio
+        )
+    }
+  )
+end
+
+# Encode left+right stereo to mid+side stereo (M/S).
+# @category Source / Audio processing
+# @argsof track.audio.stereo.ms.encode
+def stereo.ms.encode(
+  ~id=null("stereo.ms.encode"),
+  %argsof(track.audio.stereo.ms.encode[!id]),
+  (s:source)
+) =
+  tracks = source.tracks(s)
+  source(
+    id=id,
+    tracks.{
+      audio =
+        track.audio.stereo.ms.encode(
+          %argsof(track.audio.stereo.ms.encode),
+          tracks.audio
+        )
+    }
+  )
+end
+
+%ifdef track.audio.stereotool
+# Process an audio source using stereotool
+# @argsof track.audio.stereotool
+# @category Source / Audio processing
+def stereotool(
+  ~id=null("stereotool"),
+  %argsof(track.audio.stereotool[!id]),
+  s
+) =
+  let {audio, metadata, track_marks, ..._} = source.tracks(s)
+  s = track.audio.stereotool(%argsof(track.audio.stereotool[!id]), audio)
+  let replaces s =
+    source(
+      id=id,
+      {audio = (s : pcm), metadata = metadata, track_marks = track_marks}
+    )
+
+  s
+end
+
+# Output an audio source using stereotool
+# @argsof track.audio.stereotool[!active]
+# @argsof output.dummy[!id]
+# @category Source / Output
+def output.stereotool(
+  ~id=null("output.stereotool"),
+  %argsof(track.audio.stereotool[!id,!active]),
+  %argsof(output.dummy[!id]),
+  s
+) =
+  s = stereotool(%argsof(track.audio.stereotool[!id,!active]), active=false, s)
+  let replaces s = output.dummy(id=id, %argsof(output.dummy[!id]), s)
+
+  s
+end
+%endif
+
+# Defer the source's audio track by a given amount of time. Source will be
+# available when the given `delay` has been fully buffered. Use this operator
+# instead of `buffer` when buffering large amount of data as initial delay.
+#
+# This operator encodes and decodes the audio content. See `defer.pcm_s16` for
+# a low-level operator using directly the `pcm_s16` format.
+# @category Source / Audio processing
+# @argsof track.audio.defer[!id]
+# @param ~id Force the source's ID
+def defer(~id=null("defer"), %argsof(track.audio.defer[!id]), s) =
+  let {audio = a} = source.tracks(s)
+  a = track.encode.audio.pcm_s16(a)
+  a = track.audio.defer(%argsof(track.audio.defer[!id]), a)
+  a = track.decode.audio.pcm_s16(a)
+
+  source(
+    id=id,
+    {
+      audio = a,
+      metadata = track.metadata(a),
+      track_marks = track.track_marks(a)
+    }
+  )
+end
+
+# Defer the source's audio track by a given amount of time. Source will be
+# available when the given `delay` has been fully buffered. Use this operator
+# instead of `buffer` when buffering large amount of data as initial delay.
+#
+# This operator uses a source already using `pcm_s16` audio data. It can
+# be used to prevent unneeded data copy. Typically, decoders that know
+# how to decode to `pcm_s16` (like `ffmpeg`) will decode directly
+# into the format and encoders who support it (also `%ffmpeg`)
+# will encoder directly from the `pcm_s16` data. Use `defer` if you
+# prefer a more user-friendly operator.
+# @category Source / Audio processing
+# @argsof track.audio.defer[!id]
+# @param ~id Force the source's ID
+def defer.pcm_s16(
+  ~id=null("defer.pcm_s16"),
+  %argsof(track.audio.defer[!id]),
+  (s:source(audio=pcm_s16))
+) =
+  let {audio = a} = source.tracks(s)
+  a = track.audio.defer(%argsof(track.audio.defer[!id]), a)
+
+  source(
+    id=id,
+    {
+      audio = a,
+      metadata = track.metadata(a),
+      track_marks = track.track_marks(a)
+    }
+  )
+end
+
+let settings.normalize_track_gain_metadata =
+  settings.make(
+    description="Metadata used to store track gain normalization metadata",
+    "liq_normalize_track_gain"
+  )
+
+# Amplify source tracks according to track gain normalization metadata. This operator does not
+# compute that value. You can use integrated LUFS track gain or ReplayGain to compute it.
+# @category Source / Audio processing
+# @param ~id Force the value of the source ID.
+# @param s Source to be amplified.
+def normalize_track_gain(~id=null, s) =
+  amplify(id=id, override=settings.normalize_track_gain_metadata(), 1., s)
+end

--- a/tests/liq/autocue.liq
+++ b/tests/liq/autocue.liq
@@ -1,0 +1,1081 @@
+# Initialize settings for autocue
+# @category Settings
+let settings.autocue = {internal = ()}
+
+let settings.autocue.implementations =
+  settings.make(
+    description="All available autocue implementations",
+    []
+  )
+
+let settings.autocue.metadata = ()
+
+let settings.autocue.metadata.priority =
+  settings.make(
+    description="Priority for the autocue metadata resolver. Default value \
+     allows it to override both file and request metadata.",
+    10
+  )
+
+let settings.autocue.preferred =
+  settings.make(
+    description="Preferred autocue",
+    "internal"
+  )
+
+let settings.autocue.amplify_behavior =
+  settings.make(
+    description="How to proceed with loudness adjustment. Set to `\"override\"` to always prefer
+      the value provided by the `autocue` provider. Set to `\"ignore\"` to ignore all
+      loudness correction provided via the `autocue` provider. Set to
+      `\"keep\"` to always prefer user-provided values (via request annotation or file tags)
+      over values provided by the `autocue` provider.",
+    "override"
+  )
+
+let settings.autocue.amplify_aliases =
+  settings.make(
+    description="List of metadata to treat as amplify aliases when applying the \
+     `amplify_behavior` policy.",
+    ["replaygain_track_gain"]
+  )
+
+let settings.autocue.internal.metadata_override =
+  settings.make(
+    description="Disable processing when one of these metadata is found",
+    [
+      "liq_cue_in",
+      "liq_cue_out",
+      "liq_fade_in",
+      "liq_fade_in_delay",
+      "liq_fade_out",
+      "liq_fade_out_delay",
+      "liq_disable_autocue"
+    ]
+  )
+
+let settings.autocue.internal.lufs_target =
+  settings.make(
+    description="Loudness target",
+    -14.0
+  )
+
+let settings.autocue.internal.cue_in_threshold =
+  settings.make(
+    description="Cue in threshold",
+    -34.0
+  )
+
+let settings.autocue.internal.cue_out_threshold =
+  settings.make(
+    description="Cue out threshold",
+    -42.0
+  )
+
+let settings.autocue.internal.cross_threshold =
+  settings.make(
+    description="Crossfade start threshold",
+    -7.0
+  )
+
+let settings.autocue.internal.max_overlap =
+  settings.make(
+    description="Maximum allowed overlap/crossfade in seconds",
+    6.0
+  )
+
+let settings.autocue.internal.sustained_endings_enabled =
+  settings.make(
+    description="Try to optimize crossfade point on sustained endings",
+    true
+  )
+
+let settings.autocue.internal.sustained_endings_dropoff =
+  settings.make(
+    description="Max. loudness drop off immediately after crossfade point to \
+     consider it as relevant ending [percentage]",
+    15.0
+  )
+
+let settings.autocue.internal.sustained_endings_slope =
+  settings.make(
+    description="Max. loudness difference between crossfade point and cue out to \
+     consider it as relevant ending [percentage]",
+    20.0
+  )
+
+let settings.autocue.internal.sustained_endings_min_duration =
+  settings.make(
+    description="Minimum duration to consider it the ending as sustained \
+     [seconds]",
+    1.0
+  )
+
+let settings.autocue.internal.sustained_endings_threshold_limit =
+  settings.make(
+    description="Max reduction of dB thresholds compared to initial value \
+     [multiplying factor]",
+    2.0
+  )
+
+let settings.autocue.internal.ratio =
+  settings.make(
+    description="Maximum real time ratio to control speed of LUFS data analysis",
+    70.
+  )
+
+let settings.autocue.internal.timeout =
+  settings.make(
+    description="Maximum allowed processing time (estimated)",
+    10.
+  )
+
+let autocue = {internal = ()}
+
+# Register an `autocue` implementation.
+# @category Source / Audio processing
+# @param ~name Name of the implementation
+def autocue.register(~name, fn) =
+  current_implementations = settings.autocue.implementations()
+  if
+    list.assoc.mem(name, current_implementations)
+  then
+    error.raise(
+      error.invalid,
+      "Autocue implementation #{name} already exists!"
+    )
+  end
+  settings.autocue.implementations := [(name, fn), ...current_implementations]
+end
+
+# Get frames from ffmpeg.filter.ebur128
+# @flag hidden
+def autocue.internal.ebur128(~duration, ~ratio=50., ~timeout=10., filename) =
+  ignore(ratio)
+  ignore(timeout)
+  ignore(filename)
+  ignore(duration)
+%ifdef ffmpeg.filter.ebur128
+  estimated_processing_time = duration / ratio
+
+  if
+    estimated_processing_time > timeout or duration <= 0.
+  then
+    log(
+      level=2,
+      label="autocue.internal",
+      "Estimated processing duration is too long, autocue disabled! #{
+        duration
+      } / #{ratio} = #{estimated_processing_time} (Duration / Ratio = Processing \
+       duration; max. allowed: #{timeout})"
+    )
+    []
+  else
+    r = request.create(resolve_metadata=false, filename)
+    frames = ref([])
+
+    def process(s) =
+      def ebur128(s) =
+        def mk_filter(graph) =
+          let {audio = a} = source.tracks(s)
+          a = ffmpeg.filter.audio.input(graph, a)
+          let ([a], _) = ffmpeg.filter.ebur128(metadata=true, graph, a)
+
+          # ebur filter seems to generate invalid PTS.
+          a = ffmpeg.filter.asetpts(expr="N/SR/TB", graph, a)
+          a = ffmpeg.filter.audio.output(id="filter_output", graph, a)
+          source({audio = a, metadata = track.metadata(a)})
+        end
+
+        ffmpeg.filter.create(mk_filter)
+      end
+
+      s = ebur128(s)
+      s.on_metadata(synchronous=true, fun (m) -> frames := [...frames(), m])
+      s
+    end
+
+    request.process(ratio=ratio, process=process, r)
+
+    frames()
+  end
+%else
+  ignore(ratio)
+  ignore(timeout)
+  ignore(filename)
+  log(
+    level=2,
+    label="autocue.internal",
+    "ffmpeg.filter.ebur128 is not available, autocue disabled!"
+  )
+  []
+%endif
+end
+
+# Compute autocue data
+# @flag hidden
+def autocue.internal.implementation(
+  ~request_metadata,
+  ~file_metadata,
+  filename
+) =
+  lufs_target = settings.autocue.internal.lufs_target()
+  cue_in_threshold = settings.autocue.internal.cue_in_threshold()
+  cue_out_threshold = settings.autocue.internal.cue_out_threshold()
+  cross_threshold = settings.autocue.internal.cross_threshold()
+  max_overlap = settings.autocue.internal.max_overlap()
+  sustained_endings_enabled =
+    settings.autocue.internal.sustained_endings_enabled()
+  sustained_endings_dropoff =
+    settings.autocue.internal.sustained_endings_dropoff()
+  sustained_endings_slope = settings.autocue.internal.sustained_endings_slope()
+  sustained_endings_min_duration =
+    settings.autocue.internal.sustained_endings_min_duration()
+  sustained_endings_threshold_limit =
+    settings.autocue.internal.sustained_endings_threshold_limit()
+  ratio = settings.autocue.internal.ratio()
+  timeout = settings.autocue.internal.timeout()
+
+  metadata_overrides = settings.autocue.internal.metadata_override()
+
+  metadata = [...request_metadata, ...file_metadata]
+
+  if
+    list.exists(fun (el) -> list.mem(fst(el), metadata_overrides), metadata)
+  then
+    log(
+      level=2,
+      label="autocue.internal.metadata",
+      "Override metadata detected for #{filename}, disabling autocue!"
+    )
+    null
+  else
+    log(
+      level=4,
+      label="autocue.internal",
+      "Starting to process #{filename}"
+    )
+
+%ifdef request.duration.ffmpeg
+    duration = request.duration.ffmpeg(resolve_metadata=false, filename)
+%else
+    duration = null
+%endif
+
+    if
+      duration == null
+    then
+      log(
+        level=2,
+        label="autocue.internal",
+        "Could not get request duration, internal autocue disabled!"
+      )
+      null
+    else
+      duration = null.get(duration)
+
+      frames =
+        autocue.internal.ebur128(
+          duration=duration,
+          ratio=ratio,
+          timeout=timeout,
+          filename
+        )
+
+      if
+        list.length(frames) < 2
+      then
+        log(
+          level=2,
+          label="autocue.internal",
+          "Autocue computation failed!"
+        )
+        null
+      else
+        # Get the 2nd last frame which is the last with loudness data
+        frame = list.nth(frames, list.length(frames) - 2)
+
+        # Get the Integrated Loudness from the last frame (overall loudness)
+        lufs =
+          float_of_string(
+            list.assoc(default=string(lufs_target), "lavfi.r128.I", frame)
+          )
+
+        # Calc LUFS difference to target for liq_amplify
+        lufs_correction = lufs_target - lufs
+
+        # Create dB thresholds relative to LUFS target
+        lufs_cue_in_threshold = lufs + cue_in_threshold
+        lufs_cue_out_threshold = lufs + cue_out_threshold
+        lufs_cross_threshold = lufs + cross_threshold
+
+        log(
+          level=4,
+          label="autocue.internal",
+          "Processing results for #{filename}"
+        )
+
+        log(
+          level=4,
+          label="autocue.internal",
+          "lufs_correction: #{lufs_correction}"
+        )
+        log(
+          level=4,
+          label="autocue.internal",
+          "lufs_cue_in_threshold: #{lufs_cue_in_threshold}"
+        )
+        log(
+          level=4,
+          label="autocue.internal",
+          "lufs_cue_out_threshold: #{lufs_cue_out_threshold}"
+        )
+        log(
+          level=4,
+          label="autocue.internal",
+          "lufs_cross_threshold: #{lufs_cross_threshold}"
+        )
+
+        # Set cue/fade defaults
+        cue_in = ref(0.)
+        cue_out = ref(0.)
+        cross_cue = ref(0.)
+        fade_in = ref(0.)
+        fade_out = ref(0.)
+
+        # Extract timestamps for cue points
+        # Iterate over loudness data frames and set cue points based on db thresholds
+        last_ts = ref(0.)
+        current_ts = ref(0.)
+        cue_found = ref(false)
+        cross_start_idx = ref(0.)
+        cross_stop_idx = ref(0.)
+        cross_mid_idx = ref(0.)
+        cross_frame_length = ref(0.)
+        ending_fst_db = ref(0.)
+        ending_snd_db = ref(0.)
+        reset_iter_values = ref(true)
+
+        frames_rev = list.rev(frames)
+        total_frames_length = float_of_int(list.length(frames))
+        frame_idx = ref(total_frames_length - 1.)
+        lufs_cross_threshold_sustained = ref(lufs_cross_threshold)
+        lufs_cue_out_threshold_sustained = ref(lufs_cue_out_threshold)
+
+        err = error.register("assoc")
+        def find_cues(
+          frame,
+          ~reverse_order=false,
+          ~sustained_ending_check=false,
+          ~sustained_ending_recalc=false
+        ) =
+          if
+            reset_iter_values()
+          then
+            last_ts := 0.
+            current_ts := 0.
+            cue_found := false
+          end
+
+          # Get current frame loudness level and timestamp
+          db_level = list.assoc(default="nan", string("lavfi.r128.M"), frame)
+          current_ts :=
+            float_of_string(list.assoc(default="0.", "lavfi.liq.pts", frame))
+
+          # Process only valid level values
+          if
+            db_level != "nan"
+          then
+            db_level = float_of_string(db_level)
+
+            if
+              not sustained_ending_check and not sustained_ending_recalc
+            then
+              # Run regular cue point calc
+              reset_iter_values := false
+              if
+                not reverse_order
+              then
+                # Search for cue in
+                if
+                  db_level > lufs_cue_in_threshold
+                then
+                  # First time exceeding threshold
+                  cue_in := last_ts()
+
+                  # Break
+                  error.raise(
+                    err,
+                    "break list.iter"
+                  )
+                end
+              else
+                # Search for cue out and crossfade point starting from the end (reversed)
+                if
+                  db_level > lufs_cue_out_threshold and not cue_found()
+                then
+                  # Cue out
+                  cue_out := last_ts()
+                  cross_stop_idx := frame_idx()
+                  cue_found := true
+                elsif
+                  db_level > lufs_cross_threshold
+                then
+                  # Absolute crossfade cue
+                  cross_cue := last_ts()
+                  cross_start_idx := frame_idx()
+
+                  # Break
+                  error.raise(
+                    err,
+                    "break list.iter"
+                  )
+                end
+                frame_idx := frame_idx() - 1.
+              end
+            elsif
+              sustained_ending_check
+            then
+              # Check regular crossfade data for sustained ending
+              if
+                reset_iter_values()
+              then
+                frame_idx := total_frames_length - 1.
+                cross_start_idx := cross_start_idx() + 5.
+                cross_stop_idx := cross_stop_idx() - 5.
+                cross_frame_length := cross_stop_idx() - cross_start_idx()
+                cross_mid_idx := cross_stop_idx() - (cross_frame_length() / 2.)
+              end
+              reset_iter_values := false
+
+              if
+                frame_idx() < cross_start_idx()
+                or cross_frame_length() < sustained_endings_min_duration * 10.
+              then
+                error.raise(
+                  err,
+                  "break list.iter"
+                )
+              end
+
+              if
+                frame_idx() < cross_stop_idx() and frame_idx() > cross_mid_idx()
+              then
+                if
+                  ending_snd_db() < 0.
+                then
+                  ending_snd_db := (ending_snd_db() + db_level) / 2.
+                else
+                  ending_snd_db := db_level
+                end
+              end
+
+              if
+                frame_idx() > cross_start_idx()
+                and frame_idx() < cross_mid_idx()
+              then
+                if
+                  ending_fst_db() < 0.
+                then
+                  ending_fst_db := (ending_fst_db() + db_level) / 2.
+                else
+                  ending_fst_db := db_level
+                end
+              end
+              frame_idx := frame_idx() - 1.
+            elsif
+              sustained_ending_recalc
+            then
+              # Recalculate crossfade on sustained ending
+              if
+                reset_iter_values()
+              then
+                cue_out := 0.
+                cross_cue := 0.
+              end
+              reset_iter_values := false
+              if
+                db_level > lufs_cue_out_threshold_sustained()
+                and not cue_found()
+              then
+                # Cue out
+                cue_out := last_ts()
+                cue_found := true
+              end
+              if
+                db_level > lufs_cross_threshold_sustained()
+              then
+                # Absolute crossfade cue
+                cross_cue := current_ts()
+                error.raise(
+                  err,
+                  "break list.iter"
+                )
+              end
+            end
+
+            # Update last timestamp value with current
+            last_ts := current_ts()
+          end
+        end
+
+        # Search for cue_in first
+        reset_iter_values := true
+        def cue_iter_fwd(frame) =
+          find_cues(frame)
+        end
+        try
+          list.iter(cue_iter_fwd, frames)
+        catch _ do
+          log(
+            level=4,
+            label="autocue.internal",
+            "cue_iter_fwd completed."
+          )
+        end
+
+        # Reverse frames and search in reverse order for cross_cue and cue_out
+        reset_iter_values := true
+        def cue_iter_rev(frame) =
+          find_cues(frame, reverse_order=true)
+        end
+        try
+          list.iter(cue_iter_rev, frames_rev)
+        catch _ do
+          log(
+            level=4,
+            label="autocue.internal",
+            "cue_iter_rev completed."
+          )
+        end
+
+        if
+          sustained_endings_enabled
+        then
+          # Check for sustained ending
+          reset_iter_values := true
+          def sustained_ending_check_iter(frame) =
+            find_cues(frame, sustained_ending_check=true)
+          end
+          try
+            list.iter(sustained_ending_check_iter, frames_rev)
+          catch _ do
+            log(
+              level=4,
+              label="autocue.internal.sustained_ending",
+              "sustained_ending_check_iter completed."
+            )
+          end
+
+          log(
+            level=4,
+            label="autocue.internal.sustained_ending",
+            "Analysis frame length: #{cross_frame_length()}"
+          )
+          log(
+            level=4,
+            label="autocue.internal.sustained_ending",
+            "Avg. ending loudness: #{ending_fst_db()} => #{ending_snd_db()}"
+          )
+
+          # Check whether data indicate a sustained ending
+          if
+            ending_fst_db() < 0.
+          then
+            slope = ref(0.)
+            dropoff = lufs_cross_threshold / ending_fst_db()
+
+            if
+              ending_snd_db() < 0.
+            then
+              slope := ending_fst_db() / ending_snd_db()
+            end
+
+            log(
+              level=4,
+              label="autocue.internal.sustained_ending",
+              "Drop off: #{(1. - dropoff) * 100.}%"
+            )
+            log(
+              level=4,
+              label="autocue.internal.sustained_ending",
+              "Slope: #{(1. - slope()) * 100.}%"
+            )
+
+            detect_slope = slope() > 1. - sustained_endings_slope / 100.
+            detect_dropoff =
+              ending_fst_db() >
+                lufs_cross_threshold * (sustained_endings_dropoff / 100. + 1.)
+            if
+              detect_slope or detect_dropoff
+            then
+              log(
+                level=3,
+                label="autocue.internal.sustained_ending",
+                "Sustained ending detected (drop off: #{detect_dropoff} / slope: \
+                 #{detect_slope})"
+              )
+
+              if
+                detect_slope
+              then
+                lufs_cross_threshold_sustained :=
+                  max(
+                    lufs_cross_threshold * sustained_endings_threshold_limit,
+                    ending_snd_db() - 0.5
+                  )
+              else
+                lufs_cross_threshold_sustained :=
+                  max(
+                    lufs_cross_threshold * sustained_endings_threshold_limit,
+                    ending_fst_db() - 0.5
+                  )
+              end
+              lufs_cue_out_threshold_sustained =
+                ref(
+                  max(
+                    lufs_cue_out_threshold * sustained_endings_threshold_limit,
+                    lufs_cue_out_threshold +
+                      (lufs_cross_threshold_sustained() - lufs_cross_threshold)
+                  )
+                )
+
+              log(
+                level=4,
+                label="autocue.internal.sustained_ending",
+                "Changed crossfade threshold: #{lufs_cross_threshold} => #{
+                  lufs_cross_threshold_sustained()
+                }"
+              )
+              log(
+                level=4,
+                label="autocue.internal.sustained_ending",
+                "Changed cue out threshold: #{lufs_cue_out_threshold} => #{
+                  lufs_cue_out_threshold_sustained()
+                }"
+              )
+
+              cross_cue_init = cross_cue()
+              cue_out_init = cue_out()
+
+              reset_iter_values := true
+              def sustained_ending_recalc_iter(frame) =
+                find_cues(frame, sustained_ending_recalc=true)
+              end
+              try
+                list.iter(sustained_ending_recalc_iter, frames_rev)
+              catch _ do
+                log(
+                  level=4,
+                  label="autocue.internal",
+                  "sustained_ending_recalc_iter completed."
+                )
+              end
+
+              log(
+                level=4,
+                label="autocue.internal.sustained_ending",
+                "Changed crossfade point: #{cross_cue_init} => #{cross_cue()}"
+              )
+              log(
+                level=4,
+                label="autocue.internal.sustained_ending",
+                "Changed cue out point:  #{cue_out_init} => #{cue_out()}"
+              )
+            else
+              log(
+                level=3,
+                label="autocue.internal.sustained_ending",
+                "No sustained ending detected."
+              )
+            end
+          else
+            log(
+              level=3,
+              label="autocue.internal.sustained_ending",
+              "No sustained ending detected."
+            )
+          end
+        end
+
+        # Finalize cue/cross/fade values now...
+        if cue_out() == 0. then cue_out := duration end
+
+        # Calc cross/overlap duration
+        if
+          cross_cue() + 0.1 < cue_out()
+        then
+          fade_out := cue_out() - cross_cue()
+        end
+
+        # Add some margin to cue in
+        cue_in := cue_in() - 0.1
+
+        # Avoid hard cuts on cue in
+        if
+          cue_in() > 0.2
+        then
+          fade_in := 0.2
+          cue_in := cue_in() - 0.2
+        end
+
+        # Ignore super short cue in
+        if
+          cue_in() <= 0.2
+        then
+          fade_in := 0.
+          cue_in := 0.
+        end
+
+        # Limit overlap duration to maximum
+        if max_overlap < fade_in() then fade_in := max_overlap end
+
+        if
+          max_overlap < fade_out()
+        then
+          cue_shift = fade_out() - max_overlap
+          cue_out := cue_out() - cue_shift
+          fade_out := max_overlap
+          fade_out := max_overlap
+        end
+
+        (
+          {
+            amplify =
+              "#{lufs_correction} dB",
+            cue_in = cue_in(),
+            cue_out = cue_out(),
+            fade_in = fade_in(),
+            fade_out = fade_out()
+          }
+        :
+          {
+            amplify?: string,
+            cue_in: float,
+            cue_out: float,
+            fade_in: float,
+            fade_in_type?: string,
+            fade_in_curve?: float,
+            fade_out: float,
+            fade_out_type?: string,
+            fade_out_curve?: float,
+            start_next?: float,
+            extra_metadata?: [(string * string)]
+          }
+        )
+      end
+    end
+  end
+end
+
+autocue.register(name="internal", autocue.internal.implementation)
+
+# Translate autocue values into internal metadara
+# @flag hidden
+def autocue.metadata(~implementation, autocue) =
+  let {cue_in, cue_out, fade_in, fade_out} = autocue
+
+  extra_metadata = autocue.extra_metadata ?? []
+  amplify = autocue?.amplify
+
+  fade_in_type = autocue?.fade_in_type
+  fade_in_curve = autocue?.fade_in_curve
+  fade_out_type = autocue?.fade_out_type
+  fade_out_curve = autocue?.fade_out_curve
+
+  fade_out_start = cue_out - fade_out
+  let (fade_out, fade_out_start) =
+    if
+      fade_out_start < 0.
+    then
+      log(
+        level=2,
+        label="autocue",
+        "Invalid cue_out/fade_out values: #{cue_out}/#{fade_out}"
+      )
+      (0., cue_out)
+    else
+      (fade_out, fade_out_start)
+    end
+
+  start_next = autocue.start_next ?? fade_out_start
+
+  start_next =
+    if
+      start_next < cue_in or cue_out < start_next
+    then
+      log(
+        level=2,
+        label="autocue",
+        "Invalid start_next: #{start_next}"
+      )
+      fade_out_start
+    else
+      start_next
+    end
+
+  fade_out_start_next =
+    if fade_out_start < start_next then start_next - fade_out_start else 0. end
+
+  let fade_out_delay =
+    if start_next < fade_out_start then fade_out_start - start_next else 0. end
+
+  total_fade_out = fade_out + fade_out_delay
+
+  max_start_duration = cue_out - cue_in - total_fade_out
+
+  opt_arg = fun (lbl, v) -> null.defined(v) ? [(lbl, string(v))] : []
+
+  [
+    ("liq_autocue", implementation),
+    ...opt_arg("liq_amplify", amplify),
+    ("liq_cue_in", string(cue_in)),
+    ("liq_cue_out", string(cue_out)),
+    ("liq_cross_start_duration", string(fade_in)),
+    ("liq_cross_max_start_duration", string(max_start_duration)),
+    ("liq_cross_end_duration", string(total_fade_out)),
+    ("liq_fade_in", string(fade_in)),
+    ...opt_arg("liq_fade_in_type", fade_in_type),
+    ...opt_arg("liq_fade_in_curve", fade_in_curve),
+    ("liq_fade_out", string(fade_out)),
+    ("liq_fade_out_start_next", string(fade_out_start_next)),
+    ("liq_fade_out_delay", string(fade_out_delay)),
+    ...opt_arg("liq_fade_out_type", fade_out_type),
+    ...opt_arg("liq_fade_out_curve", fade_out_curve),
+    ...extra_metadata
+  ]
+end
+
+let file.autocue = ()
+
+# Return the file's autocue values as metadata suitable for metadata override.
+# @category Source / Audio processing
+def file.autocue.metadata(~request_metadata, uri) =
+  preferred_implementation = settings.autocue.preferred()
+  implementations = settings.autocue.implementations()
+  autocue_metadata = autocue.metadata
+
+  let (implementation_name, implementation) =
+    if
+      list.assoc.mem(preferred_implementation, implementations)
+    then
+      log(
+        level=4,
+        label="autocue",
+        "Using preferred #{preferred_implementation} autocue implementation."
+      )
+      (
+        preferred_implementation,
+        list.assoc(preferred_implementation, implementations)
+      )
+    elsif
+      list.length(implementations) > 0
+    then
+      let [(name, implementation)] = implementations
+      log(
+        level=4,
+        label="autocue",
+        "Using first available #{name} autocue implementation."
+      )
+      (name, implementation)
+    else
+      error.raise(
+        error.not_found,
+        "No autocue implementation found!"
+      )
+    end
+
+  r =
+    request.create(
+      excluded_metadata_resolvers=decoder.metadata.reentrant(),
+      uri
+    )
+
+  if
+    not request.resolve(r)
+  then
+    request.destroy(r)
+    log(
+      level=2,
+      label="autocue",
+      "Couldn't resolve uri: #{uri}"
+    )
+    []
+  else
+    autocue =
+      try
+        autocue =
+          implementation(
+            request_metadata=request_metadata,
+            file_metadata=request.metadata(r),
+            request.filename(r)
+          )
+        request.destroy(r)
+        autocue
+      catch err do
+        request.destroy(r)
+        log(
+          level=2,
+          label="autocue",
+          "Error while processing autocue: #{err}"
+        )
+        error.raise(err)
+      end
+
+    if
+      null.defined(autocue)
+    then
+      autocue_metadata(implementation=implementation_name, null.get(autocue))
+    else
+      log(
+        level=2,
+        label="autocue.metadata",
+        "No autocue data returned for file #{uri}"
+      )
+      []
+    end
+  end
+end
+
+# Enable autocue metadata resolver. This resolver will process any file
+# decoded by Liquidsoap and add cue-in/out and crossfade metadata when these
+# values can be computed. This function sets `settings.request.prefetch` to `2`
+# to account for the latency introduced by the `autocue` computation when resolving
+# requests. For a finer-grained processing, use the `autocue:` protocol.
+# @category Liquidsoap
+def enable_autocue_metadata() =
+  if settings.request.prefetch() == 1 then settings.request.prefetch := 2 end
+
+  def autocue_metadata(~metadata, fname) =
+    metadata_overrides = settings.autocue.internal.metadata_override()
+
+    if
+      list.exists(fun (el) -> list.mem(fst(el), metadata_overrides), metadata)
+    then
+      log(
+        level=2,
+        label="autocue.metadata",
+        "Override metadata detected for #{fname}, disabling autocue!"
+      )
+      []
+    else
+      autocue_metadata = file.autocue.metadata(request_metadata=metadata, fname)
+
+      all_amplify = [...settings.autocue.amplify_aliases(), "liq_amplify"]
+
+      user_supplied_amplify =
+        list.filter_map(
+          fun (el) ->
+            if list.mem(fst(el), all_amplify) then fst(el) else null end,
+          metadata
+        )
+
+      user_supplied_amplify_labels =
+        string.concat(
+          separator=", ",
+          user_supplied_amplify
+        )
+
+      autocue_metadata =
+        if
+          settings.autocue.amplify_behavior() == "ignore"
+        then
+          [...list.assoc.remove("liq_amplify", autocue_metadata)]
+        else
+          if
+            user_supplied_amplify != []
+          then
+            if
+              settings.autocue.amplify_behavior() == "keep"
+            then
+              log(
+                level=3,
+                label="autocue.metadata",
+                "User-supplied amplify metadata detected: #{
+                  user_supplied_amplify_labels
+                }, keeping user-provided data."
+              )
+              list.assoc.remove("liq_amplify", autocue_metadata)
+            elsif
+              settings.autocue.amplify_behavior() == "override"
+            then
+              log(
+                level=3,
+                label="autocue.metadata",
+                "User-supplied amplify metadata detected: #{
+                  user_supplied_amplify_labels
+                }, overriding with autocue data."
+              )
+              [
+                ...autocue_metadata,
+                # This replaces all user-provided tags with the value returned by
+                # the autocue implementation.
+                ...list.map(
+                  fun (lbl) -> (lbl, autocue_metadata["liq_amplify"]),
+                  user_supplied_amplify
+                )
+              ]
+            else
+              log(
+                level=2,
+                label="autocue.metadata",
+                "Invalid value for `settings.autocue.amplify_behavior`: #{
+                  settings.autocue.amplify_behavior()
+                }"
+              )
+              autocue_metadata
+            end
+          else
+            autocue_metadata
+          end
+        end
+      log(level=4, label="autocue.metadata", "#{autocue_metadata}")
+      autocue_metadata
+    end
+  end
+
+%ifdef settings.decoder.mime_types.ffmpeg
+  mime_types = settings.decoder.mime_types.ffmpeg()
+  file_extensions = settings.decoder.file_extensions.ffmpeg()
+%else
+  mime_types = null
+  file_extensions = null
+%endif
+
+  decoder.metadata.add(
+    mime_types=mime_types,
+    file_extensions=file_extensions,
+    priority=settings.autocue.metadata.priority,
+    reentrant=true,
+    "autocue",
+    autocue_metadata
+  )
+end
+
+# Define autocue protocol
+# @flag hidden
+def protocol.autocue(~rlog:_, ~maxtime:_, arg) =
+  cue_metadata = file.autocue.metadata(request_metadata=[], arg)
+
+  if
+    cue_metadata != []
+  then
+    cue_metadata =
+      list.map(fun (el) -> "#{fst(el)}=#{string.quote(snd(el))}", cue_metadata)
+    cue_metadata = string.concat(separator=",", cue_metadata)
+    "annotate:#{cue_metadata}:#{arg}"
+  else
+    log(
+      level=2,
+      label="autocue.protocol",
+      "No autocue data returned for URI #{arg}!"
+    )
+    arg
+  end
+end
+protocol.add(
+  "autocue",
+  protocol.autocue,
+  doc="Adding automatically computed cues/crossfade metadata",
+  syntax="autocue:uri"
+)

--- a/tests/liq/clock.liq
+++ b/tests/liq/clock.liq
@@ -1,0 +1,14 @@
+# Create a new clock and assign it to a list of sources.
+# @category Liquidsoap
+# @param ~sync Synchronization mode. One of: `"auto"`, `"cpu"`, `"passive"` or \
+#              `"none"`. Defaults to `"auto"`, which synchronizes with the CPU \
+#              clock if none of the active sources are attached to their own \
+#              clock (e.g. ALSA input, etc). `"cpu"` always synchronizes with \
+#              the CPU clock. `"none"` removes all synchronization control.
+# @param ~on_error Error callback executed when a streaming error occurs. \
+#                  When passed, all streaming errors are silenced. Intended \
+#                  mostly for debugging purposes.
+def clock.assign_new(~sync="auto", ~id=null, ~on_error=null, sources) =
+  c = clock.create(id=id, sync=sync, on_error=on_error)
+  list.iter(fun (s) -> c.unify(s.clock), sources)
+end

--- a/tests/liq/cron.liq
+++ b/tests/liq/cron.liq
@@ -1,0 +1,74 @@
+let cron.tab = ref([])
+
+# Add an entry to the cron tab.
+# @param ~id Optional task ID.
+# @param c Cron entry
+# @param handler Function to execute
+# @method id ID to be used to remove the task.
+# @category Programming
+def cron.add(~id=null, c, handler) =
+  id = id ?? string.id.default(default="cron.task", null)
+
+  if
+    list.exists(fun ({id = i}) -> i == id, cron.tab())
+  then
+    error.raise(
+      error.invalid,
+      "Cron tab entry with ID #{id} already exists!"
+    )
+  end
+
+  let {test} = cron.parse(c)
+  log.info(
+    label="cron",
+    "Adding cron.tab entry #{c} (cron id: #{id})"
+  )
+  cron.tab :=
+    [...cron.tab(), {id = id, cron = c, test = test, handler = handler}]
+
+  {id = id}
+end
+
+# Remove a cron tab entry. ID is returned during
+# the task's registration
+# @category Programming
+def cron.remove(id) =
+  if
+    list.exists(fun ({id = i}) -> i == id, cron.tab())
+  then
+    log.info(
+      label="cron",
+      "Removing cron.tab entry #{id}"
+    )
+    cron.tab := list.filter(fun ({id = i}) -> i != id, cron.tab())
+  else
+    log.important(
+      label="cron",
+      "Cannot remove cron.tab entry #{id}: entry does not exist!"
+    )
+  end
+end
+
+# Main cron thread.
+thread.when(
+  fast=false,
+  every=20.,
+  {0s-30s},
+  {
+    list.iter(
+      fun ({id, cron, test, handler}) ->
+        begin
+          if
+            test()
+          then
+            log.info(
+              label="cron",
+              "Executing cron.tab entry #{cron} (id: #{id})"
+            )
+            thread.run(fast=false, handler)
+          end
+        end,
+      cron.tab()
+    )
+  }
+)

--- a/tests/liq/error.liq
+++ b/tests/liq/error.liq
@@ -1,0 +1,48 @@
+let error.assertion = error.register("assertion")
+let error.clock = error.register("clock")
+let error.eval = error.register("eval")
+let error.file = error.register("file")
+let error.file.cross_device = error.register("file.cross_device")
+let error.http = error.register("http")
+let error.invalid = error.register("invalid")
+let error.json = error.register("json")
+let error.not_found = error.register("not_found")
+let error.output = error.register("output")
+let error.socket = error.register("socket")
+let error.string = error.register("string")
+
+# Ensure that a condition is satisfied (raise `error.assertion` exception
+# otherwise).
+# @category Programming
+# @param c Condition which should be satisfied.
+def assert(c) =
+  if
+    not c
+  then
+    error.raise(
+      error.assertion,
+      "Assertion failed."
+    )
+  end
+end
+
+let error.failure = error.register("failure")
+
+# Major failure.
+# @category Programming
+# @param msg Explanation about the failure.
+def failwith(msg) =
+  error.raise(error.failure, msg)
+end
+
+# Return error kind
+# @category Programming
+def error.kind(err) =
+  error.methods(err).kind
+end
+
+# Return error message
+# @category Programming
+def error.message(err) =
+  error.methods(err).message
+end

--- a/tests/liq/extra/audio.liq
+++ b/tests/liq/extra/audio.liq
@@ -1,0 +1,677 @@
+# Compand the signal.
+# @category Source / Audio processing
+# @flag extra
+# @argsof track.audio.compand
+def compand(~id=null("compand"), %argsof(track.audio.compand[!id]), s) =
+  tracks = source.tracks(s)
+  source(
+    id=id,
+    tracks.{
+      audio = track.audio.compand(%argsof(track.audio.compand), tracks.audio)
+    }
+  )
+end
+
+# Comb filter
+# @category Source / Audio processing
+# @argsof track.audio.comb
+# @flag extra
+def comb(~id=null("comb"), %argsof(track.audio.comb[!id]), s) =
+  tracks = source.tracks(s)
+  source(
+    id=id,
+    tracks.{audio = track.audio.comb(%argsof(track.audio.comb), tracks.audio)}
+  )
+end
+
+# Compress the signal.
+# @category Source / Audio processing
+# @argsof track.audio.compress
+# @flag extra
+def compress(%argsof(track.audio.compress), s) =
+  tracks = source.tracks(s)
+  let {gain, rms, ...audio} =
+    track.audio.compress(%argsof(track.audio.compress), tracks.audio)
+
+  source(id=id, tracks.{audio = audio}).{gain = gain, rms = rms}
+end
+
+# Exponential compressor.
+# @category Source / Audio processing
+# @argsof track.audio.compress.exponential
+# @flag extra
+def compress.exponential(%argsof(track.audio.compress.exponential), s) =
+  tracks = source.tracks(s)
+  source(
+    id=id,
+    tracks.{
+      audio =
+        track.audio.compress.exponential(
+          %argsof(track.audio.compress.exponential),
+          tracks.audio
+        )
+    }
+  )
+end
+
+# A limiter. This is a `compress` with tweaked parameters.
+# @category Source / Audio processing
+# @flag extra
+def limit(
+  ~id=null,
+  ~attack=getter(50.),
+  ~release=getter(200.),
+  ~ratio=getter(20.),
+  ~threshold=getter(-2.),
+  ~pre_gain=getter(0.),
+  ~gain=getter(0.),
+  s
+) =
+  compress(
+    id=id,
+    attack=attack,
+    release=release,
+    ratio=ratio,
+    threshold=threshold,
+    pre_gain=pre_gain,
+    gain=gain,
+    s
+  )
+end
+
+let limiter = limit
+
+# A bandpass filter obtained by chaining a low-pass and a high-pass filter.
+# @category Source / Audio processing
+# @flag extra
+# @param id Force the value of the source ID.
+# @param ~low Lower frequency of the bandpass filter.
+# @param ~high Higher frequency of the bandpass filter.
+# @param ~q Q factor.
+def filter.iir.eq.low_high(~id=null, ~low, ~high, ~q=1., s) =
+  s =
+    if
+      not (getter.is_constant(high) and getter.get(high) == infinity)
+    then
+      filter.iir.eq.low(id=id, frequency=high, q=q, s)
+    else
+      s
+    end
+
+  s =
+    if
+      not (getter.is_constant(low) and getter.get(low) == 0.)
+    then
+      filter.iir.eq.high(id=id, frequency=low, q=q, s)
+    else
+      s
+    end
+
+  s
+end
+
+# Multiband compression. The list in argument specifies
+# - the `frequency` below which we should apply compression (it is above previous band)
+# - the `attack` time (ms)
+# - the `release` time (ms)
+# - the compression `ratio`
+# - the `threshold` for compression
+# - the `gain` for the band
+# @category Source / Audio processing
+# @param ~limit Also apply limiting to bands.
+# @param l Parameters for compression bands.
+# @param s Source on which multiband compression should be applied.
+# @flag extra
+def compress.multiband(~limit=true, ~wet=getter(1.), s, l) =
+  # Check that the bands are with increasing frequencies.
+  for i = 0 to list.length(l) - 2 do
+    if
+      getter.get(list.nth(l, i + 1).frequency) <
+        getter.get(list.nth(l, i).frequency)
+    then
+      failwith(
+        "Bands should be sorted."
+      )
+    end
+
+  end
+
+  # Process a band
+  def band(low, band) =
+    high =
+      if
+        getter.is_constant(band.frequency)
+        and getter.get(band.frequency) >= float_of_int(audio.samplerate()) / 2.
+      then
+        infinity
+      else
+        band.frequency
+      end
+
+    s = filter.iir.eq.low_high(low=low, high=high, s)
+    s =
+      compress(
+        attack=band.attack,
+        release=band.release,
+        threshold=band.threshold,
+        ratio=band.ratio,
+        gain=band.gain,
+        s
+      )
+
+    if limit then limiter(s) else s end
+  end
+
+  ls =
+    list.mapi(
+      fun (i, b) ->
+        band(if i == 0 then 0. else list.nth(l, i - 1).frequency end, b),
+      l
+    )
+
+  c = add(normalize=false, ls)
+  s =
+    if
+      not getter.is_constant(wet) or getter.get(wet) != 1.
+    then
+      add(
+        normalize=false,
+        [amplify({1. - getter.get(wet)}, s), amplify(wet, c)]
+      )
+    else
+      c
+    end
+
+  # Seal l element type
+  if false then () else list.hd(l) end
+
+  # Limit to avoid bad surprises
+  limiter(s)
+end
+
+# Compress and normalize, producing a more uniform and "full" sound.
+# @category Source / Audio processing
+# @flag extra
+# @param s The input source.
+def nrj(s) =
+  compress(threshold=-15., ratio=3., gain=3., normalize(s))
+end
+
+# Multiband-compression.
+# @category Source / Audio processing
+# @flag extra
+# @param s The input source.
+def sky(s) =
+  # 3-band crossover
+  low = fun (s) -> filter.iir.eq.low(frequency=168., s)
+  mh = fun (s) -> filter.iir.eq.high(frequency=100., s)
+  mid = fun (s) -> filter.iir.eq.low(frequency=1800., s)
+  high = fun (s) -> filter.iir.eq.high(frequency=1366., s)
+
+  # Add back
+  add(
+    normalize=false,
+    [
+      compress(
+        attack=100.,
+        release=200.,
+        threshold=-20.,
+        ratio=6.,
+        gain=6.7,
+        knee=0.3,
+        low(s)
+      ),
+      compress(
+        attack=100.,
+        release=200.,
+        threshold=-20.,
+        ratio=6.,
+        gain=6.7,
+        knee=0.3,
+        mid(mh(s))
+      ),
+      compress(
+        attack=100.,
+        release=200.,
+        threshold=-20.,
+        ratio=6.,
+        gain=6.7,
+        knee=0.3,
+        high(s)
+      )
+    ]
+  )
+end
+
+# Add some bass to the sound.
+# @category Source / Audio processing
+# @param ~frequency Frequency below which sound is considered as bass.
+# @param ~gain Amount of boosting (dB).
+# @param s Source whose bass should be boosted
+# @flag extra
+def bass_boost(~frequency=getter(200.), ~gain=getter(10.), s) =
+  bass = limit(pre_gain=gain, filter.iir.eq.low(frequency=frequency, s))
+  add([s, bass])
+end
+
+%ifdef soundtouch
+# Increases the pitch, making voices sound like on helium.
+# @category Source / Audio processing
+# @flag extra
+# @param s The input source.
+def helium(s) =
+  soundtouch(pitch=1.5, s)
+end
+%endif
+
+# Remove low frequencies often produced by microphones.
+# @flag extra
+# @category Source / Audio processing
+# @param ~frequency Frequency under which sound should be lowered.
+# @param s The input source.
+def mic_filter(~frequency=200., s) =
+  filter(freq=frequency, q=1., mode="high", s)
+end
+
+# Mix between dry and wet sources. Useful for testing effects. Typically:
+# ```
+# c = interactive.float("wetness", min=0., max=1., 1.)
+# s = dry_wet(c, s, effect(s))
+# ```
+# and vary `c` to hear the difference between the source without and with
+# the effect.
+# @flag extra
+# @category Source / Audio processing
+# @param ~power If `true` use constant power mixing.
+# @param wetness Wetness coefficient, from 0 (fully dry) to  1 (fully wet).
+# @param dry Dry source.
+# @param wet Wet source.
+def dry_wet(~power=false, wetness, dry, wet) =
+  add(
+    power=power,
+    weights=[getter.map(fun (x) -> 1. - x, wetness), wetness],
+    [dry, wet]
+  )
+end
+
+# Generate DTMF tones.
+# @flag extra
+# @category Source / Sound synthesis
+# @param ~duration Duration of a tone (in seconds).
+# @param ~delay Dealy between two successive tones (in seconds).
+# @param dtmf String describing DTMF tones to generates: it should contains characters 0 to 9, A to D, or * or #.
+def replaces dtmf(~duration=0.1, ~delay=0.05, dtmf) =
+  l = ref([])
+  for i = 0 to string.bytes.length(dtmf) - 1 do
+    c = string.sub(encoding="ascii", dtmf, start=i, length=1)
+    let (row, col) =
+      if
+        c == "1"
+      then
+        (697., 1209.)
+      elsif
+        c == "2"
+      then
+        (697., 1336.)
+      elsif
+        c == "3"
+      then
+        (697., 1477.)
+      elsif
+        c == "A"
+      then
+        (697., 1633.)
+      elsif
+        c == "4"
+      then
+        (770., 1209.)
+      elsif
+        c == "5"
+      then
+        (770., 1336.)
+      elsif
+        c == "6"
+      then
+        (770., 1477.)
+      elsif
+        c == "B"
+      then
+        (770., 1633.)
+      elsif
+        c == "7"
+      then
+        (852., 1209.)
+      elsif
+        c == "8"
+      then
+        (852., 1336.)
+      elsif
+        c == "9"
+      then
+        (852., 1477.)
+      elsif
+        c == "C"
+      then
+        (852., 1633.)
+      elsif
+        c == "*"
+      then
+        (941., 1209.)
+      elsif
+        c == "0"
+      then
+        (941., 1336.)
+      elsif
+        c == "#"
+      then
+        (941., 1477.)
+      elsif
+        c == "D"
+      then
+        (941., 1633.)
+      else
+        (0., 0.)
+      end
+
+    s = add([sine(row, duration=duration), sine(col, duration=duration)])
+    l := blank(duration=delay)::l()
+    l := s::l()
+
+  end
+
+  l = list.rev(l())
+  sequence(l)
+end
+
+# Mixing table controllable via source methods and optional
+# server/telnet commands.
+# @flag extra
+# @category Source / Audio processing
+# @param ~id Force the value of the source ID.
+# @param ~register_server_commands Register corresponding server commands
+# @param ~normalize Normalize source's volume by the number of mixed sources.
+def mix(~id=null, ~register_server_commands=true, ~normalize=false, sources) =
+  id = string.id.default(default="mixer", id)
+  inputs =
+    list.map(
+      fun (s) ->
+        begin
+          volume = ref(1.)
+          is_selected = ref(false)
+          is_single = ref(false)
+          {
+            volume = volume,
+            selected = is_selected,
+            single = is_single,
+            source = s
+          }
+        end,
+      sources
+    )
+
+  insert_metadata_fn = ref(fun (_) -> ())
+  sources =
+    list.map(
+      fun (input) ->
+        begin
+          s = amplify(input.volume, input.source)
+          s.on_track(
+            synchronous=true,
+            fun (_) -> if input.single() then input.selected := false end
+          )
+
+          s.on_metadata(
+            synchronous=true,
+            fun (m) ->
+              begin
+                fn = insert_metadata_fn()
+                fn(m)
+              end
+          )
+
+          switch([(input.selected, s)])
+        end,
+      inputs
+    )
+
+  s = add(normalize=normalize, sources)
+  let {metadata = _, ...tracks} = source.tracks(s)
+  s = source(tracks)
+  insert_metadata_fn := s.insert_metadata
+  let {track_marks = _, ...tracks} = source.tracks(s)
+  s = source(id=id, tracks)
+  if
+    register_server_commands
+  then
+    def status(input) =
+      "ready=#{source.is_ready(input.source)} selected=#{input.selected()} \
+       single=#{input.single()} volume=#{int_of_float(input.volume() * 100.)}% \
+       remaining=#{source.remaining(input.source)}"
+    end
+
+    s.register_command(
+      description="Skip current track on all enabled sources.",
+      "skip",
+      fun (_) ->
+        begin
+          list.iter(
+            fun (input) ->
+              if input.selected() then source.skip(input.source) end,
+            inputs
+          )
+
+          "OK"
+        end
+    )
+
+    s.register_command(
+      description="Set volume for a given source.",
+      usage="volume <source nb> <vol%>",
+      "volume",
+      fun (v) ->
+        begin
+          try
+            let [i, v] = r/\s/.split(v)
+            input = list.nth(inputs, int_of_string(i))
+            input.volume := float_of_string(v)
+            status(input)
+          catch _ do
+            "Usage: volume <source nb> <vol%>"
+          end
+        end
+    )
+
+    s.register_command(
+      description="Enable/disable a source.",
+      usage="select <source nb> <true|false>",
+      "select",
+      fun (arg) ->
+        begin
+          try
+            let [i, b] = r/\s/.split(arg)
+            input = list.nth(inputs, int_of_string(i))
+            input.selected := (b == "true")
+            status(input)
+          catch _ do
+            "Usage: select <source nb> <true|false>"
+          end
+        end
+    )
+
+    s.register_command(
+      description="Enable/disable automatic stop at the end of track.",
+      usage="single <source nb> <true|false>",
+      "single",
+      fun (arg) ->
+        begin
+          try
+            let [i, b] = r/\s/.split(arg)
+            input = list.nth(inputs, int_of_string(i))
+            input.single := (b == "true")
+            status(input)
+          catch _ do
+            "Usage: single <source nb> <true|false>"
+          end
+        end
+    )
+
+    s.register_command(
+      description="Display current status.",
+      "status",
+      fun (i) ->
+        begin
+          try
+            status(list.nth(inputs, int_of_string(i)))
+          catch _ do
+            "Usage: status <source nb>"
+          end
+        end
+    )
+
+    s.register_command(
+      description="Print the list of input sources.",
+      "inputs",
+      fun (_) ->
+        string.concat(
+          separator=" ",
+          list.map(fun (input) -> source.id(input.source), inputs)
+        )
+    )
+  end
+
+  s.{inputs = inputs}
+end
+
+# Indicate beats.
+# @category Source / Sound synthesis
+# @param ~frequency Frequency of the sound.
+# @param bpm Number of beats per minute.
+# @flag extra
+def metronome(~frequency=440., bpm=60.) =
+  volume_down = 0.
+  beat_duration = 0.1
+  s = sine(frequency)
+
+  def f() =
+    if s.time() mod (60. / bpm) <= beat_duration then 1. else volume_down end
+  end
+
+  amplify(f, s)
+end
+
+# Mixes two streams, with faded transitions between the state when only the
+# normal stream is available and when the special stream gets added on top of
+# it.
+# @category Source / Fade
+# @flag extra
+# @param ~duration Duration of the fade in seconds.
+# @param ~p       Portion of amplitude of the normal source in the mix.
+# @param ~normal  The normal source, which could be called the carrier too.
+# @param ~special The special source.
+def smooth_add(~duration=1., ~p=getter(0.2), ~normal, ~special) =
+  p = getter.function(p)
+  last_p = ref(p())
+
+  def c(fn, s) =
+    def v() =
+      fn = fn()
+      fn()
+    end
+
+    fade.scale(v, s)
+  end
+
+  special_volume = ref(fun () -> 0.)
+  special = c(special_volume, special)
+  normal_volume = ref(fun () -> 1.)
+  normal = c(normal_volume, normal)
+
+  def to_special({starting}) =
+    last_p := p()
+    q = 1. - last_p()
+    normal_volume := mkfade(start=1., stop=last_p(), duration=duration, normal)
+    special_volume := mkfade(stop=q, duration=duration, starting)
+    starting
+  end
+
+  def to_blank(x) =
+    b = x.starting
+    normal_volume := mkfade(start=last_p(), duration=duration, normal)
+    if
+      null.defined(x?.ending)
+    then
+      special_volume :=
+        mkfade(start=1. - last_p(), duration=duration, null.get(x?.ending))
+      sequence([null.get(x?.ending), b])
+    else
+      b
+    end
+  end
+
+  special =
+    fallback([special.{on_select = to_special}, blank().{on_select = to_blank}])
+
+  add(normalize=false, [normal, special])
+end
+
+%ifencoder %ffmpeg
+# Output an MPEG-DASH playlist.
+# @category Source / Output
+# @flag extra
+# @param ~id Force the value of the source ID.
+# @param ~codec Codec to use for audio (following FFmpeg's conventions).
+# @param ~fallible Allow the child source to fail, in which case the output will be (temporarily) stopped.
+# @param ~start Automatically start outputting whenever possible. If true, an infallible (normal) output will start outputting as soon as it is created, and a fallible output will (re)start as soon as its source becomes available for streaming.
+# @param ~playlist Playlist name
+# @param ~directory Directory to write to
+def output.file.dash(
+  ~id=null,
+  ~fallible=false,
+  ~codec="libmp3lame",
+  ~bitrate=128,
+  ~start=true,
+  ~playlist="stream.mpd",
+  ~directory,
+  s
+) =
+  enc = %ffmpeg(format = "dash", %audio(codec = codec, b = "#{bitrate}k"))
+  output.file(
+    id=id,
+    fallible=fallible,
+    start=start,
+    enc,
+    "#{(directory : string)}/#{playlist}",
+    s
+  )
+end
+%endif
+
+# Return a source with a `set_volume` method.
+# This method takes the same arguments as `mkfade`
+# and updates the source volume with a corresponding
+# fade curve
+# @category Source / Audio processing
+# @flag extra
+# @param ~id Force the value of the source ID.
+def smooth_volume(~id=null("smooth_volume"), s) =
+  last_volume = ref(1.)
+  volume_ref = ref(fun () -> 1.)
+
+  def volume() =
+    fn = volume_ref()
+    fn()
+  end
+
+  def set_volume(%argsof(mkfade[!start,!stop,!delay,!on_done]), v) =
+    volume_ref :=
+      mkfade(
+        %argsof(mkfade[!start,!stop,!delay,!on_done]),
+        start=last_volume(),
+        stop=v,
+        s
+      )
+    last_volume := v
+  end
+
+  amplify(id=id, volume, s).{set_volume = set_volume}
+end

--- a/tests/liq/extra/audioscrobbler.liq
+++ b/tests/liq/extra/audioscrobbler.liq
@@ -1,0 +1,482 @@
+let error.audioscrobbler = error.register("audioscrobbler")
+
+let settings.audioscrobbler =
+  settings.make.void(
+    "Audioscrobbler settings"
+  )
+
+let settings.audioscrobbler.api_key =
+  settings.make(
+    description="Default API key for audioscrobbler",
+    ""
+  )
+
+let settings.audioscrobbler.api_secret =
+  settings.make(
+    description="Default API secret for audioscrobbler",
+    ""
+  )
+
+audioscrobbler = ()
+
+def audioscrobbler.request(
+  ~base_url="http://ws.audioscrobbler.com/2.0",
+  ~api_key=null,
+  ~api_secret=null,
+  params
+) =
+  api_key = api_key ?? settings.audioscrobbler.api_key()
+  api_secret = api_secret ?? settings.audioscrobbler.api_secret()
+
+  if
+    api_key == "" or api_secret == ""
+  then
+    error.raise(
+      error.audioscrobbler,
+      "`api_key` or `api_secret` missing!"
+    )
+  end
+
+  params = [("api_key", api_key), ...params]
+
+  sig_params = list.sort(fun (v, v') -> string.compare(fst(v), fst(v')), params)
+  sig_params = list.map(fun (v) -> "#{fst(v)}#{(snd(v) : string)}", sig_params)
+  sig_params = string.concat(separator="", sig_params)
+
+  api_sig = string.digest("#{sig_params}#{api_secret}")
+
+  http.post(
+    base_url,
+    headers=[("Content-Type", "application/x-www-form-urlencoded")],
+    data=http.www_form_urlencoded([...params, ("api_sig", api_sig)])
+  )
+end
+
+def audioscrobbler.check_response(resp) =
+  let xml.parse ({lfm = {xml_params = {status}}} :
+    {lfm: {xml_params: {status: string}}}
+  ) = resp
+  if
+    (status == "failed")
+  then
+    error_ref = error
+    let xml.parse ({lfm = {error = {xml_params = {code}}}} :
+      {lfm: {error: string.{ xml_params: {code: int} }}}
+    ) = resp
+    error_ref.raise(
+      error_ref.audioscrobbler,
+      "Error #{code}: #{error}"
+    )
+  end
+end
+
+def audioscrobbler.auth(~username, ~password, ~api_key=null, ~api_secret=null) =
+  resp =
+    audioscrobbler.request(
+      api_key=api_key,
+      api_secret=api_secret,
+      [
+        ("method", "auth.getMobileSession"),
+        ("username", username),
+        ("password", password)
+      ]
+    )
+
+  audioscrobbler.check_response(resp)
+
+  try
+    let xml.parse ({lfm = {session = {key}}} :
+      {lfm: {session: {name: string, key: string}}}
+    ) = resp
+    key
+  catch err do
+    error.raise(
+      error.invalid,
+      "Invalid response: #{resp}, error: #{err}"
+    )
+  end
+end
+
+let audioscrobbler.api = {track = ()}
+
+# Submit a track to the audioscrobbler
+# `track.updateNowPlaying` API.
+# @category Interaction
+def audioscrobbler.api.track.updateNowPlaying(
+  ~username,
+  ~password,
+  ~session_key=null,
+  ~api_key=null,
+  ~api_secret=null,
+  ~artist,
+  ~track,
+  ~album=null,
+  ~context=null,
+  ~trackNumber=null,
+  ~mbid=null,
+  ~albumArtist=null,
+  ~duration=null
+) =
+  session_key =
+    session_key
+      ?? audioscrobbler.auth(
+        username=username,
+        password=password,
+        api_key=api_key,
+        api_secret=api_secret
+      )
+
+  params =
+    [
+      ("track", track),
+      ("artist", artist),
+      ...(null.defined(album) ? [("album", null.get(album))] : []),
+      ...(null.defined(context) ? [("context", null.get(context))] : []),
+      ...(
+        null.defined(trackNumber)
+          ? [("trackNumber", string((null.get(trackNumber) : int)))]
+          : []
+      ),
+      ...(null.defined(mbid) ? [("mbid", null.get(mbid))] : []),
+      ...(
+        null.defined(albumArtist)
+          ? [("albumArtist", null.get(albumArtist))]
+          : []
+      ),
+      ...(
+        null.defined(duration)
+          ? [("duration", string((null.get(duration) : int)))]
+          : []
+      )
+    ]
+
+  log.info(
+    label="audioscrobbler.api.track.updateNowPlaying",
+    "Submitting updateNowPlaying with: #{params}"
+  )
+
+  resp =
+    audioscrobbler.request(
+      api_key=api_key,
+      api_secret=api_secret,
+      [...params, ("method", "track.updateNowPlaying"), ("sk", session_key)]
+    )
+
+  audioscrobbler.check_response(resp)
+
+  try
+    let xml.parse (v :
+      {
+        lfm: {
+          nowplaying: {
+            track: string.{ xml_params: {corrected: int} },
+            artist: string.{ xml_params: {corrected: int} },
+            album: string?.{ xml_params: {corrected: int} },
+            albumArtist: string?.{ xml_params: {corrected: int} },
+            ignoredMessage: {xml_params: {code: int}}
+          },
+          xml_params: {status: string}
+        }
+      }
+    ) = resp
+
+    log.info(
+      label="audioscrobbler.api.track.updateNowPlaying",
+      "Done submitting updateNowPlaying with: #{params}"
+    )
+
+    v
+  catch err do
+    error.raise(
+      error.invalid,
+      "Invalid response: #{resp}, error: #{err}"
+    )
+  end
+end
+
+# @flag hidden
+def audioscrobbler.api.apply_meta(
+  ~name,
+  ~username,
+  ~password,
+  ~api_key,
+  ~api_secret,
+  ~session_key,
+  fn,
+  m
+) =
+  def c(v) =
+    v == "" ? null : v
+  end
+  track = m["title"]
+  artist = m["artist"]
+
+  if
+    track == "" or artist == ""
+  then
+    log.info(
+      label=name,
+      "No artist or track present: metadata submission disabled!"
+    )
+  else
+    album = c(m["album"])
+    trackNumber =
+      try
+        null.map(int_of_string, c(m["tracknumber"]))
+      catch _ do
+        null
+      end
+    albumArtist = c(m["albumartist"])
+    ignore(
+      fn(
+        username=username,
+        password=password,
+        api_key=api_key,
+        api_secret=api_secret,
+        session_key=session_key,
+        track=track,
+        artist=artist,
+        album=album,
+        trackNumber=trackNumber,
+        albumArtist=albumArtist
+      )
+    )
+  end
+end
+
+# Submit a track using its metadata to the audioscrobbler
+# `track.updateNowPlaying` API.
+# @category Interaction
+def audioscrobbler.api.track.updateNowPlaying.metadata(
+  ~username,
+  ~password,
+  ~session_key=null,
+  ~api_key=null,
+  ~api_secret=null,
+  m
+) =
+  audioscrobbler.api.apply_meta(
+    username=username,
+    password=password,
+    session_key=session_key,
+    api_key=api_key,
+    api_secret=api_secret,
+    name="audioscrobbler.api.track.updateNowPlaying",
+    audioscrobbler.api.track.updateNowPlaying,
+    m
+  )
+end
+
+# Submit a track to the audioscrobbler
+# `track.scrobble` API.
+# @category Interaction
+def audioscrobbler.api.track.scrobble(
+  ~username,
+  ~password,
+  ~session_key=null,
+  ~api_key=null,
+  ~api_secret=null,
+  ~artist,
+  ~track,
+  ~timestamp=null,
+  ~album=null,
+  ~context=null,
+  ~streamId=null,
+  ~chosenByUser=true,
+  ~trackNumber=null,
+  ~mbid=null,
+  ~albumArtist=null,
+  ~duration=null
+) =
+  session_key =
+    session_key
+      ?? audioscrobbler.auth(
+        username=username,
+        password=password,
+        api_key=api_key,
+        api_secret=api_secret
+      )
+
+  params =
+    [
+      ("track", track),
+      ("artist", artist),
+      ("timestamp", string(timestamp ?? time())),
+      ...(null.defined(album) ? [("album", null.get(album))] : []),
+      ...(null.defined(context) ? [("context", null.get(context))] : []),
+      ...(null.defined(streamId) ? [("streamId", null.get(streamId))] : []),
+      ("chosenByUser", chosenByUser ? "1" : "0"),
+      ...(
+        null.defined(trackNumber)
+          ? [("trackNumber", string((null.get(trackNumber) : int)))]
+          : []
+      ),
+      ...(null.defined(mbid) ? [("mbid", null.get(mbid))] : []),
+      ...(
+        null.defined(albumArtist)
+          ? [("albumArtist", null.get(albumArtist))]
+          : []
+      ),
+      ...(
+        null.defined(duration)
+          ? [("duration", string((null.get(duration) : int)))]
+          : []
+      )
+    ]
+
+  log.info(
+    label="audioscrobbler.api.track.scrobble",
+    "Submitting updateNowPlaying with: #{params}"
+  )
+
+  resp =
+    audioscrobbler.request(
+      api_key=api_key,
+      api_secret=api_secret,
+      [...params, ("method", "track.scrobble"), ("sk", session_key)]
+    )
+
+  audioscrobbler.check_response(resp)
+
+  try
+    let xml.parse (v :
+      {
+        lfm: {
+          scrobbles: {
+            scrobble: {
+              track: string.{ xml_params: {corrected: int} },
+              artist: string.{ xml_params: {corrected: int} },
+              album: string?.{ xml_params: {corrected: int} },
+              albumArtist: string?.{ xml_params: {corrected: int} },
+              timestamp: float,
+              ignoredMessage: {xml_params: {code: int}}
+            },
+            xml_params: {ignored: int, accepted: int}
+          },
+          xml_params: {status: string}
+        }
+      }
+    ) = resp
+
+    log.info(
+      label="audioscrobbler.api.track.scrobble",
+      "Done submitting scrobble with: #{params}"
+    )
+
+    v
+  catch err do
+    error.raise(
+      error.invalid,
+      "Invalid response: #{resp}, error: #{err}"
+    )
+  end
+end
+
+# Submit a track to the audioscrobbler
+# `track.scrobble` API using its metadata.
+# @category Interaction
+def audioscrobbler.api.track.scrobble.metadata(
+  ~username,
+  ~password,
+  ~session_key=null,
+  ~api_key=null,
+  ~api_secret=null,
+  m
+) =
+  audioscrobbler.api.apply_meta(
+    username=username,
+    password=password,
+    session_key=session_key,
+    api_key=api_key,
+    api_secret=api_secret,
+    name="audioscrobbler.api.track.scrobble",
+    audioscrobbler.api.track.scrobble,
+    m
+  )
+end
+
+# Submit songs using audioscrobbler, respecting the full protocol:
+# First signal song as now playing when starting, and
+# then submit song when it ends.
+# @category Interaction
+# @flag extra
+# @param ~source Source for tracks. Should be one of: "broadcast", "user", "recommendation" or "unknown". Since liquidsoap is intended for radio broadcasting, this is the default. Sources other than user don't need duration to be set.
+# @param ~delay Submit song when there is only this delay left, in seconds.
+# @param ~force If remaining time is null, the song will be assumed to be skipped or cut, and not submitted. Set this to `true` to prevent this behavior
+# @param ~metadata_preprocessor Metadata pre-processor callback. Can be used to change metadata on-the-fly before sending to nowPlaying/scrobble. If returning an empty metadata, nothing is sent at all.
+def audioscrobbler.submit(
+  ~username,
+  ~password,
+  ~api_key=null,
+  ~api_secret=null,
+  ~delay=10.,
+  ~force=false,
+  ~metadata_preprocessor=fun (m) -> m,
+  s
+) =
+  session_key =
+    audioscrobbler.auth(
+      username=username,
+      password=password,
+      api_key=api_key,
+      api_secret=api_secret
+    )
+
+  def now_playing(m) =
+    try
+      audioscrobbler.api.track.updateNowPlaying.metadata(
+        username=username,
+        password=password,
+        api_key=api_key,
+        api_secret=api_secret,
+        session_key=session_key,
+        metadata_preprocessor(m)
+      )
+    catch err do
+      log.important(
+        "Error while submitting nowplaying info for #{source.id(s)}: #{err}"
+      )
+    end
+  end
+
+  s = source.methods(s)
+  s.on_metadata(synchronous=false, now_playing)
+
+  f =
+    fun (rem, m) ->
+      # Avoid skipped songs
+      if
+        rem > 0. or force
+      then
+        thread.run(
+          delay=0.,
+          {
+            try
+              audioscrobbler.api.track.scrobble.metadata(
+                username=username,
+                password=password,
+                api_key=api_key,
+                api_secret=api_secret,
+                session_key=session_key,
+                metadata_preprocessor(m)
+              )
+            catch err do
+              log.important(
+                "Error while submitting scrobble info for #{source.id(s)}: #{
+                  err
+                }"
+              )
+            end
+          }
+        )
+      else
+        log(
+          label="audioscrobbler.submit",
+          level=4,
+          "Remaining time null: will not submit song (song skipped ?)"
+        )
+      end
+  s.on_position(synchronous=true, remaining=true, position=delay, f)
+
+  (s : source)
+end

--- a/tests/liq/extra/deprecations.liq
+++ b/tests/liq/extra/deprecations.liq
@@ -1,0 +1,976 @@
+# Deprecated APIs.
+
+# Mark a function as deprecated.
+# @flag deprecated
+# @category Liquidsoap
+# @param old Old function name.
+# @param new New function name.
+def deprecated(old, new) =
+  new =
+    if
+      new == ""
+    then
+      ""
+    else
+      " Please use \"#{new}\" instead."
+    end
+  log.severe(
+    label="lang.deprecated",
+    "WARNING: \"#{old}\" is deprecated and will be removed in future version.#{
+      new
+    }"
+  )
+end
+
+%ifdef input.external.rawaudio
+# Deprecated: this function has been replaced by `input.external.rawaudio`.
+# @flag deprecated
+def replaces input.external(%argsof(input.external.rawaudio), cmd) =
+  deprecated("input.external", "input.external.rawaudio")
+  input.external.rawaudio(%argsof(input.external.rawaudio), cmd)
+end
+%endif
+
+# Deprecated: this function has been replaced by `string.quote`.
+# @flag deprecated
+def quote(s) =
+  deprecated("quote", "string.quote")
+  string.quote(s)
+end
+
+let string.utf8 = ()
+
+# Deprecated: this function has been replaced by `string.escape`.
+# @flag deprecated
+def string.utf8.escape(s) =
+  deprecated("string.utf8.escape", "string.escape")
+  string.escape(s)
+end
+
+# Deprecated: use mksafe and playlist instead.
+# @flag deprecated
+def playlist.safe(
+  ~id=null,
+  ~mime_type="",
+  ~mode="randomize",
+  ~on_track={()},
+  ~prefix="",
+  ~reload=0,
+  ~reload_mode="seconds",
+  uri
+) =
+  deprecated("playlist.safe", "")
+  ignore(on_track)
+  mksafe(
+    playlist(
+      id=id,
+      mime_type=mime_type,
+      mode=mode,
+      prefix=prefix,
+      reload=reload,
+      reload_mode=reload_mode,
+      uri
+    )
+  )
+end
+
+# Deprecated: this function has been replaced by `thread.run.recurrent`.
+# @flag deprecated
+def add_timeout(~fast=true, delay, f) =
+  deprecated("add_timeout", "thread.run.recurrent")
+  thread.run.recurrent(fast=fast, delay=delay, f)
+end
+
+# Deprecated: this function has been replaced by `thread.when`.
+# @flag deprecated
+def exec_at(~freq=1., ~pred, f) =
+  deprecated("exec_at", "thread.when")
+  thread.when(every=freq, pred, f)
+end
+
+# Deprecated: this function has been replaced by `file.which`.
+# @flag deprecated
+def which(f) =
+  deprecated("which", "file.which")
+  file.which(f) ?? ""
+end
+
+base64 = ()
+
+# Deprecated: this function has been replaced by `string.base64.decode`.
+# @flag deprecated
+def base64.decode(s) =
+  deprecated("base64.decode", "string.base64.decode")
+  string.base64.decode(s)
+end
+
+# Deprecated: this function has been replaced by `string.base64.encode`.
+# @flag deprecated
+def base64.encode(s) =
+  deprecated("base64.encode", "string.base64.encode")
+  string.base64.encode(s)
+end
+
+# Deprecated: this function has been replaced with `playlist`, setting
+# `reload_mode` argument to `"never"` and `loop` to `false`.
+# @flag deprecated
+def playlist.once(
+  ~id=null,
+  ~random=false,
+  ~reload_mode="",
+  ~prefetch=1,
+  ~filter=fun (_) -> true,
+  uri
+) =
+  deprecated("playlist.once", "playlist")
+  mode = if random then "randomize" else "normal" end
+  reload_mode = if reload_mode == "" then "never" else reload_mode end
+  playlist(
+    reload_mode=reload_mode,
+    loop=false,
+    id=id,
+    mode=mode,
+    prefetch=prefetch,
+    check_next=filter,
+    uri
+  )
+end
+
+# Deprecated: use metadata.map
+# @flag deprecated
+def map_metadata(%argsof(metadata.map), fn, s) =
+  deprecated("map_metadata", "metadata.map")
+  metadata.map(%argsof(metadata.map), fn, s)
+end
+
+# Deprecated: this function has been replaced by `metadata.map`.
+# @flag deprecated
+def rewrite_metadata(l, ~insert_missing=true, ~update=true, ~strip=false, s) =
+  deprecated("rewrite_metadata", "metadata.map")
+
+  def map(m) =
+    def apply(x) =
+      label = fst(x)
+      value = snd(x)
+      (label, value % m)
+    end
+
+    list.map(apply, l)
+  end
+
+  metadata.map(
+    map,
+    insert_missing=insert_missing,
+    update=update,
+    strip=strip,
+    s
+  )
+end
+
+# Deprecated: this function will be removed in a future release
+# @flag deprecated
+def id(~id=null, s) =
+  deprecated("id", "")
+  ignore(id)
+  s
+end
+
+# Deprecated: flow is no longer maintained
+# Register a radio on Liquidsoap Flows.
+# @category Liquidsoap
+# @flag deprecated
+# @param ~radio   Name of the radio.
+# @param ~website URL of the website of the radio.
+# @param ~description Description of the radio.
+# @param ~genre   Genre of the radio (rock or rap or etc.).
+# @param ~streams List of streams for the radio described by \
+#                 a pair of strings consisting of the format of the stream \
+#                 and the url of the stream. The format should be \
+#                 of the form "ogg/128k" consisting of the codec and \
+#                 the bitrate, separated by "/".
+def register_flow(
+  ~server="",
+  ~user="default",
+  ~password="default",
+  ~email="",
+  ~radio,
+  ~website,
+  ~description,
+  ~genre,
+  ~streams,
+  s
+) =
+  deprecated("register_flow", "")
+
+  # If the server is "", we get the server from sf.net
+  server =
+    if
+      server == ""
+    then
+      let data = http.get("http://liquidsoap.info/flows_server")
+      if
+        data.status_code == 200
+      then
+        data
+      else
+        # If sf is down, we use the hardcoded server
+        "http://savonet.rastageeks.org/liqflows.py"
+      end
+    else
+      server
+    end
+
+  log(
+    level=4,
+    "Flows server: #{server}"
+  )
+
+  # Initial variables
+  ping_period = 600.
+
+  # Pinging period in seconds
+
+  # Fix default parameters
+  # and set request function.
+  base_params =
+    [
+      ("v", "0.0"),
+      ("user", user),
+      ("password", password),
+      ("email", email),
+      ("radio", radio)
+    ]
+
+  def request(~cmd, ~params) =
+    def log(~level, x) =
+      log(label=radio, level=level, x)
+    end
+
+    log(
+      level=4,
+      "Processing command #{cmd} with arguments:"
+    )
+
+    def log_arg(x) =
+      let (label, value) = x
+      log(
+        level=4,
+        "  #{label}: #{value}"
+      )
+    end
+
+    list.iter(log_arg, params)
+    cmd = url.encode(cmd)
+    params = list.append(base_params, params)
+
+    def f(z) =
+      let (x, y) = z
+      y = url.encode(y)
+      "#{x}=#{y}"
+    end
+
+    params = string.concat(separator="&", list.map(f, params))
+    url = "#{server}?cmd=#{cmd}&#{params}"
+
+    # TODO: do something with errors!
+    answer = http.get(url)
+    log(
+      level=4,
+      "Response status: #{answer.http_version} #{answer.status_code} #{
+        answer.status_message
+      }"
+    )
+
+    log(
+      level=4,
+      "Response headers:"
+    )
+    list.iter(log_arg, answer.headers)
+    log(
+      level=4,
+      "Response content: #{answer}"
+    )
+  end
+
+  # Register radio
+  params =
+    [
+      ("radio_website", website),
+      ("radio_description", description),
+      ("radio_genre", genre)
+    ]
+
+  request(
+    cmd="add radio",
+    params=params
+  )
+
+  # Ping
+  def ping() =
+    ignore(
+      request(
+        cmd="ping radio",
+        params=[]
+      )
+    )
+    ping_period
+  end
+
+  thread.run.recurrent(fast=false, delay=ping_period, ping)
+
+  # Register streams
+  def register_stream(format_url) =
+    let (format, url) = format_url
+    params = [("stream_format", format), ("stream_url", url)]
+    request(
+      cmd="add stream",
+      params=params
+    )
+  end
+
+  request(
+    cmd="clear streams",
+    params=[]
+  )
+  list.iter(register_stream, streams)
+
+  # Metadata update
+  def metadata(m) =
+    artist = m["artist"]
+    title = m["title"]
+    params = [("m_title", title), ("m_artist", artist)]
+    request(cmd="metadata", params=params)
+  end
+
+  s.on_metadata(metadata)
+end
+
+# Deprecated: this function has been replaced by `source.fail`.
+# @flag deprecated
+def empty(~id=null) =
+  deprecated("empty", "source.fail")
+  source.fail(id=id)
+end
+
+# Deprecated: use `request.create` instead.
+# @flag deprecated
+def request.create.raw(%argsof(request.create), uri) =
+  deprecated("request.create.raw", "request.create")
+  request.create(%argsof(request.create), uri)
+end
+
+# Deprecated: use `file.remove` instead.
+# @flag deprecated
+def file.unlink(filename) =
+  deprecated("file.unlink", "file.remove")
+  file.remove(filename)
+end
+
+# Deprecated: was designed for transitions only and is not
+# needed anymore. Use `file.out` instead.
+# @flag deprecated
+def fade.final(~id="fade.final", ~duration=3., ~type="lin", s) =
+  deprecated("fade.final", "fade.out")
+  fn = mkfade(start=1., stop=0., type=type, duration=duration, s)
+  should_play = ref(true)
+
+  def fn() =
+    v = fn()
+    if v == 0. then should_play := false end
+    v
+  end
+
+  s = fade.scale(id=id, fn, s)
+  switch([(should_play, s)])
+end
+
+# Deprecated: was designed for transitions only and is not
+# needed anymore. Use `fade.in` instead.
+# @flag deprecated
+def fade.initial(~id="fade.initial", ~duration=3., ~type="lin", s) =
+  deprecated("fade.initial", "fade.in")
+  fn = mkfade(start=0., stop=1., type=type, duration=duration, s)
+  fade.scale(id=id, fn, s)
+end
+
+# Deprecated: use `process.read` instead.
+# @flag deprecated
+def get_process_output(%argsof(process.read), cmd) =
+  deprecated("get_process_output", "process.read")
+  process.read(%argsof(process.read), cmd)
+end
+
+# Deprecated: use `process.read.lines` instead.
+# @flag deprecated
+def get_process_lines(%argsof(process.read.lines), cmd) =
+  deprecated("get_process_lines", "process.read.lines")
+  process.read.lines(%argsof(process.read.lines), cmd)
+end
+
+# Deprecated: use `process.test` instead.
+# @flag deprecated
+def test_process(%argsof(process.test), cmd) =
+  deprecated("test_process", "process.test")
+  process.test(%argsof(process.test), cmd)
+end
+
+# Deprecated: use `process.run` instead.
+# @flag deprecated
+def system(command) =
+  deprecated("system", "process.run")
+  process.run(command)
+end
+
+# Deprecated: use `blank.detect` instead
+# @flag deprecated
+def on_blank(%argsof(blank.detect), f, s) =
+  deprecated("on_blank", "blank.detect")
+  s = blank.detect(%argsof(blank.detect), s)
+  s.on_blank(synchronous=true, f)
+  s
+end
+
+# Deprecated: use `blank.skip` instead
+# @flag deprecated
+def skip_blank(%argsof(blank.skip), s) =
+  deprecated("skip_blank", "blank.skip")
+  blank.skip(%argsof(blank.skip), s)
+end
+
+# Deprecated: use `blank.eat` instead
+# @flag deprecated
+def eat_blank(%argsof(blank.eat), s) =
+  deprecated("eat_blank", "blank.eat")
+  blank.eat(%argsof(blank.eat), s)
+end
+
+# Deprecated: use `blank.strip` instead
+# @flag deprecated
+def strip_blank(%argsof(blank.strip), s) =
+  deprecated("strip_blank", "blank.strip")
+  blank.strip(%argsof(blank.strip), s)
+end
+
+# Deprecated: use `time.local` instead
+# @flag deprecated
+def localtime(t) =
+  deprecated("localtime", "time.local")
+  time.local(t)
+end
+
+# Deprecated: use `time.utc` instead
+# @flag deprecated
+def gmtime(t) =
+  deprecated("gmtime", "time.utc")
+  time.utc(t)
+end
+
+# Deprecated: use `time` instead
+# @flag deprecated
+def gettimeofday() =
+  deprecated("gettimeofday", "time")
+  time()
+end
+
+# @flag deprecated
+def output.preferred(~id=null, ~fallible=false, ~start=true, s) =
+  deprecated("output.preferred", "output")
+  output(id=id, fallible=fallible, start=start, s)
+end
+
+# Deprecated: use `output` instead.
+# @flag deprecated
+def out(s) =
+  deprecated("out", "output")
+  output(mksafe(s))
+end
+
+# Deprecated: use `input` instead.
+# @flag deprecated
+def in(~id=null, ~start=true, ~fallible=false) =
+  deprecated("in", "input")
+  input(id=id, start=start, fallible=fallible)
+end
+
+# Deprecated: use `source.available` instead.
+# @flag deprecated
+def mkavailable(
+  ~id="mkavailable",
+  ~active=getter(false),
+  ~available=getter(true),
+  s
+) =
+  deprecated("mkavailable", "source.available")
+  output.dummy(switch([(getter.function(active), s)]), fallible=true)
+  switch(id=id, [(getter.function(available), s)])
+end
+
+# Deprecated: use `at` instead.
+# @flag deprecated
+def at(pred, s) =
+  deprecated("at", "source.available")
+  source.available(s, pred)
+end
+
+https = ()
+
+# Deprecated: use `http.get` instead.
+# @flag deprecated
+def https.get(%argsof(http.get), url) =
+  deprecated("https.get", "http.get")
+  http.get(%argsof(http.get), url)
+end
+
+# Deprecated: use `http.put` instead.
+# @flag deprecated
+def https.put(%argsof(http.put), url) =
+  deprecated("https.put", "http.put")
+  http.put(%argsof(http.put), url)
+end
+
+# Deprecated: use `http.post` instead.
+# @flag deprecated
+def https.post(%argsof(http.post), url) =
+  deprecated("https.post", "http.post")
+  http.post(%argsof(http.post), url)
+end
+
+# Deprecated: use `http.head` instead.
+# @flag deprecated
+def https.head(%argsof(http.head), url) =
+  deprecated("https.head", "http.head")
+  http.head(%argsof(http.head), url)
+end
+
+# Deprecated: use `http.delete` instead.
+# @flag deprecated
+def https.delete(%argsof(http.delete), url) =
+  deprecated("https.delete", "http.delete")
+  http.delete(%argsof(http.delete), url)
+end
+
+%ifdef input.http
+# Deprecated: use `input.http` instead
+# @flag deprecated
+def input.https(%argsof(input.http), url) =
+  deprecated("input.https", "input.http")
+  input.http(%argsof(input.http), url)
+end
+%endif
+
+%ifdef source.say_metadata
+# Deprecated: use `source.say_metadata` instead
+# @flag deprecated
+def say_metadata(s, ~pattern) =
+  def pattern(m) =
+    pattern % m
+  end
+
+  source.say_metadata(pattern=pattern, s)
+end
+%endif
+
+# Deprecated: use `playlist.parse.register` instead
+# @flag deprecated
+def add_playlist_parser(%argsof(playlist.parse.register), s) =
+  deprecated("add_playlist_parser", "playlist.parse.register")
+  playlist.parse.register(%argsof(playlist.parse.register), s)
+end
+
+# Deprecated: use `json.stringify` instead
+# @flag deprecated
+# @argsof json.stringify
+def json_of(%argsof(json.stringify), v) =
+  deprecated("json_of", "json.stringify")
+  json.stringify(%argsof(json.stringify), v)
+end
+
+# Deprecated: use `json.parse` instead
+# @flag deprecated
+# @argsof json.parse
+def of_json(%argsof(json.parse), v) =
+  deprecated("of_json", "json.parse")
+  json.parse(%argsof(json.parse), v)
+end
+
+# Deprecated: use `playlist` instead
+# @flag deprecated
+def playlist.reloadable(
+  ~id=null,
+  ~mime_type="",
+  ~mode="randomize",
+  ~on_track={()},
+  ~prefix="",
+  ~reload=0,
+  ~reload_mode="seconds",
+  uri
+) =
+  deprecated("playlist.reloadable", "playlist")
+  ignore(on_track)
+  playlist(
+    id=id,
+    mime_type=mime_type,
+    mode=mode,
+    prefix=prefix,
+    reload=reload,
+    reload_mode=reload_mode,
+    uri
+  )
+end
+
+# Deprecated: use `request.dynamic` instead
+# @flag deprecated
+def request.dynamic.list(%argsof(request.dynamic), f) =
+  deprecated("request.dynamic.list", "request.dynamic")
+  add = ref(fun (_) -> ())
+
+  def f() =
+    l = f()
+    if
+      l != []
+    then
+      let [r, ...q] = list.rev(l)
+      r = (r : request)
+      list.iter(add(), list.rev(q))
+      r
+    else
+      null
+    end
+  end
+
+  s = request.dynamic(%argsof(request.dynamic), f)
+  add := fun (r) -> ignore(s.add(r))
+  s
+end
+
+# Deprecated: use `process.run` instead
+# @flag deprecated
+def run_process(%argsof(process.run), p) =
+  deprecated("run_process", "process.run")
+  x = process.run(%argsof(process.run), p)
+  (x.stdout, x.stderr, ("#{x.status}", x.status.description))
+end
+
+# Deprecated: use `list.assoc.mem` instead
+# @flag deprecated
+def list.mem_assoc(x, y) =
+  deprecated("list.mem_assoc", "list.assoc.mem")
+  list.assoc.mem(x, y)
+end
+
+# Deprecated: use `runtime.gc.full_major` instead
+# @flag deprecated
+def garbage_collect() =
+  deprecated("garbage_collect", "runtime.gc.full_major")
+  runtime.gc.full_major()
+end
+
+# Deprecated: use `video.alpha.of_color`
+# @flag deprecated
+def video.transparent(%argsof(video.alpha.of_color), s) =
+  deprecated("video.transparent", "video.alpha.of_color")
+  video.alpha.of_color(%argsof(video.alpha.of_color), s)
+end
+
+# Deprecated: use `request.resolved`
+# @flag deprecated
+def request.ready(r) =
+  deprecated("request.ready", "request.resolved")
+  request.resolved(r)
+end
+
+# Deprecated: use `environment.get`
+# @flag deprecated
+def getenv(default="", v) =
+  deprecated("getenv", "environment.get")
+  environment.get(default=default, v)
+end
+
+# Deprecated: use `environment.set`
+# @flag deprecated
+def setenv(k, v) =
+  deprecated("setenv", "environment.set")
+  environment.set(k, v)
+end
+
+# Deprecated: use `getpid`
+# @flag deprecated
+def getpid() =
+  deprecated("getpid", "process.pid")
+  process.pid()
+end
+
+# Deprecated: use `file.mime`
+# @flag deprecated
+def get_mime(fname) =
+  deprecated("get_mime", "file.mime")
+  file.mime(fname) ?? ""
+end
+
+# Deprecated: use `string`.
+# @flag deprecated
+def string_of(s) =
+  deprecated("string_of", "string")
+  string(s)
+end
+
+# Deprecated: use `string.float`.
+# @flag deprecated
+def string_of_float(x) =
+  deprecated("string_of_float", "string.float")
+  string.float(x)
+end
+
+# Deprecated: use `protocol.add`.
+# @flag deprecated
+def add_protocol(%argsof(protocol.add), name, fn) =
+  deprecated("add_protocol", "protocol.add")
+  protocol.add(%argsof(protocol.add), name, fn)
+end
+
+# Deprecated: use `decoder.metadata.add`.
+# @flag deprecated
+def add_metadata_resolver(name, fn) =
+  deprecated("add_metadata_resolver", "decoder.metadata.add")
+  decoder.metadata.add(name, fn)
+end
+
+# Deprecated: use `source.mux.audio`.
+# @flag deprecated
+def mux_audio(%argsof(source.mux.audio), s) =
+  deprecated("mux_audio", "source.mux.audio")
+  source.mux.audio(%argsof(source.mux.audio), s)
+end
+
+# Deprecated: use `source.mux.video`.
+# @flag deprecated
+def mux_video(%argsof(source.mux.video), s) =
+  deprecated("mux_video", "source.mux.video")
+  source.mux.video(%argsof(source.mux.video), s)
+end
+
+# Deprecated: use `source.mux.midi`
+# @flag deprecated
+def mux_midi(%argsof(source.mux.midi), s) =
+  deprecated("mux_midi", "source.mux.midi")
+  source.mux.midi(%argsof(source.mux.midi), s)
+end
+
+# Deprecated: use `source.drop.audio`
+# @flag deprecated
+def drop_audio(%argsof(source.drop.audio), s) =
+  deprecated("drop_audio", "source.drop.audio")
+  source.drop.audio(%argsof(source.drop.audio), s)
+end
+
+# Deprecated: use `source.drop.video`
+# @flag deprecated
+def drop_video(%argsof(source.drop.video), s) =
+  deprecated("drop_video", "source.drop.video")
+  source.drop.video(%argsof(source.drop.video), s)
+end
+
+# Deprecated: use `source.drop.midi`
+# @flag deprecated
+def drop_midi(%argsof(source.drop.midi), s) =
+  deprecated("drop_midi", "source.drop.midi")
+  source.drop.midi(%argsof(source.drop.midi), s)
+end
+
+# Deprecated: use `source.drop.metadata`
+# @flag deprecated
+def drop_metadata(%argsof(source.drop.metadata), s) =
+  deprecated("drop_metadata", "source.drop.metadata")
+  source.drop.metadata(%argsof(source.drop.metadata), s)
+end
+
+# Deprecated: use `source.stereo`
+# @flag deprecated
+def audio_to_stereo(~id=null, s) =
+  deprecated("audio_to_stereo", "stereo")
+  stereo(id=id, s)
+end
+
+# Deprecated: use `source.tracks` and `source`
+# @flag deprecated
+def merge_tracks(~id=null, s) =
+  deprecated("merge_tracks", "source")
+  let {track_marks = _, ...tracks} = source.tracks(s)
+  source(id=id, tracks)
+end
+
+%ifdef compress
+# Deprecated: use `compress`
+# @flag deprecated
+def compress.old(~id=null, s) =
+  deprecated("compress.old", "compress")
+  compress(id=id, s)
+end
+%endif
+
+# Deprecated: use `thread.pause`
+# @flag deprecated
+def sleep(s) =
+  deprecated("sleep", "thread.pause")
+  thread.pause(s)
+end
+
+# Deprecated: use `video.add_rectangle`.
+# @flag deprecated
+def video.rectangle(%argsof(video.add_rectangle), s) =
+  video.add_rectangle(%argsof(video.add_rectangle), s)
+end
+
+# Deprecated: use `video.add_line`.
+# @flag deprecated
+def video.line(%argsof(video.add_line), src, tgt, s) =
+  video.add_line(%argsof(video.add_line), src, tgt, s)
+end
+
+# Deprecated: integrated into requests resolution.
+# @flag deprecated
+def cue_cut(
+  ~id=null(""),
+  ~cue_in_metadata="",
+  ~cue_out_metadata="",
+  ~on_cue_in=(fun () -> ()),
+  ~on_cue_out=(fun () -> ()),
+  s
+) =
+  ignore(id)
+  ignore(cue_in_metadata)
+  ignore(cue_out_metadata)
+  ignore(on_cue_in)
+  ignore(on_cue_out)
+  log.severe(
+    label="lang.deprecated",
+    "WARNING: cue_cut has been removed and integrated directly into requests \
+     resolution! This operator can be safely removed from your script now."
+  )
+  s
+end
+
+# Deprecated: use the on_metadata source method
+# @flag deprecated
+def on_metadata(~id:_, s, fn) =
+  log.severe(
+    label="lang.deprecated",
+    "Use the on_metadata source method!"
+  )
+  source.methods(s).on_metadata(synchronous=true, fn)
+  s
+end
+
+# Deprecated: use the on_track source method
+# @flag deprecated
+def on_track(~id:_, s, fn) =
+  log.severe(
+    label="lang.deprecated",
+    "Use the on_track source method!"
+  )
+  source.methods(s).on_track(synchronous=true, fn)
+  s
+end
+
+# Deprecated: use the last_metadata source method
+# @flag deprecated
+def source.last_metadata(~id:_, s) =
+  log.severe(
+    label="lang.deprecated",
+    "Use the last_metadata source method!"
+  )
+  source.methods(s).last_metadata()
+end
+
+# Deprecated: use the on_frame source method
+# @flag deprecated
+def source.on_frame(~id:_, ~before=true, s, fn) =
+  log.severe(
+    label="lang.deprecated",
+    "Use the on_frame source method!"
+  )
+  source.methods(s).on_frame(synchronous=true, before=before, fn)
+end
+
+# Deprecated: use the on_position source method
+# @flag deprecated
+def source.on_offset(
+  ~id:_,
+  ~force:allow_partial=false,
+  ~offset:position,
+  fn,
+  s
+) =
+  log.severe(
+    label="lang.deprecated",
+    "Use the on_position source method!"
+  )
+  source.methods(s).on_position(
+    synchronous=true,
+    remaining=false,
+    allow_partial=allow_partial,
+    position=position,
+    fn
+  )
+end
+
+# Deprecated: use the on_position source method
+# @flag deprecated
+def source.on_end(~id:_, ~delay:position, s, fn) =
+  log.severe(
+    label="lang.deprecated",
+    "Use the on_position source method!"
+  )
+  source.methods(s).on_position(
+    synchronous=true,
+    remaining=true,
+    allow_partial=false,
+    position=position,
+    fn
+  )
+end
+
+# Deprecated: use the insert_metadata source method
+# @flag deprecated
+def insert_metadata(~id:_=null, s) =
+  log.severe(
+    label="lang.deprecated",
+    "WARNING: `insert_metadata` operator is deprecated. Please use the \
+     `insert_metadata` source method!"
+  )
+  source.methods(s)
+end
+
+# Deprecated: use `normalize_track_gain`
+# @flag deprecated
+def replaygain(~id=null, s) =
+  log.severe(
+    label="lang.deprecated",
+    "Use the normalize_track_gain operator!"
+  )
+
+  def add_legacy_meta(m) =
+    if
+      m["replaygain_track_gain"] != ""
+      and m[settings.normalize_track_gain_metadata()] == ""
+    then
+      [(settings.normalize_track_gain_metadata(), m["replaygain_track_gain"])]
+    else
+      []
+    end
+  end
+
+  s = metadata.map(add_legacy_meta, s)
+
+  amplify(id=id, override=settings.normalize_track_gain_metadata(), 1., s)
+end
+
+# Deprecated: use json.object
+# @flag deprecated
+def replaces json() =
+  log.severe(
+    label="lang.deprecated",
+    "Use `json.object`"
+  )
+  json.object()
+end

--- a/tests/liq/extra/externals.liq
+++ b/tests/liq/extra/externals.liq
@@ -1,0 +1,196 @@
+# Enable the external ffmpeg decoder.
+# @category Liquidsoap
+# @param ~file_extensions File extensions to decode. Should not be empty
+# @param ~mimes Mime types to decode. Empty list means any type.
+# @param ~binary Path to the `ffmpeg` binary.
+def enable_external_ffmpeg_decoder(~binary="ffmpeg", ~mimes, ~file_extensions) =
+  decoder.add(
+    name="FFMPEG",
+    description="Decode files using the ffmpeg decoder binary",
+    mimes=mimes,
+    file_extensions=file_extensions,
+    fun (~rlog, ~maxtime:_, fname) ->
+      begin
+        # File is cleaned up as part of the request workflow.
+        outfile = file.temp(cleanup=false, "ffmpeg", ".wav")
+        try
+          let {status = {code}} =
+            process.run(
+              "#{binary} -i #{process.quote(fname)} #{process.quote(outfile)}"
+            )
+          code == 0 ? outfile : null
+        catch err do
+          file.remove(outfile)
+          rlog(
+            "Error while decoding #{fname} using ffmpeg: #{err}"
+          )
+          null
+        end
+      end
+  )
+end
+
+# Enable the external openmpt123 decoder
+# @category Liquidsoap
+# @param ~file_extensions File extensions to decode.
+# @param ~mimes Mime types to decode. Empty list means any type.
+# @param ~options Extra options.
+# @param ~binary Path to the `ffmpeg` binary.
+def enable_external_openmpt123_decoder(
+  ~binary="openmpt123",
+  ~mimes=[
+    "audio/it",
+    "audio/xm",
+    "audio/s3m",
+    "audio/x-mod",
+    "audio/mod",
+    "audio/module-xm",
+    "audio/x-mod",
+    "application/playerpro",
+    "audio/x-s3m",
+    "application/soundapp",
+    "audio/med",
+    "audio/x-xm"
+  ],
+  ~file_extensions=[
+    "xm",
+    "mtm",
+    "amf",
+    "stm",
+    "ult",
+    "wow",
+    "dmf",
+    "it",
+    "s3m",
+    "far",
+    "mod",
+    "mt2",
+    "okt",
+    "med",
+    "669"
+  ],
+  ~options=""
+) =
+  decoder.add(
+    name="OPENMPT123",
+    description="Decode files using the openmpt123 decoder binary",
+    mimes=mimes,
+    file_extensions=file_extensions,
+    fun (~rlog, ~maxtime:_, infile) ->
+      begin
+        ret =
+          process.read.lines(
+            "#{binary} --info #{process.quote(infile)} 2>&1"
+          )
+        def get_meta(l, s) =
+          ret = string.extract(pattern="^(\\w+).+:\\s(.+)$", s)
+          if
+            list.length(ret) > 2
+          then
+            label = ret[1]
+            val = ret[2]
+            label = "openmpt:#{string.case(lower=true, label)}"
+            ["#{string.quote(label)}=#{string.quote(val)}", ...l]
+          else
+            l
+          end
+        end
+        meta = list.fold(get_meta, [], ret)
+
+        prefix =
+          if
+            meta == []
+          then
+            ""
+          else
+            "annotate:#{string.concat(separator=',', meta)}:"
+          end
+
+        # File is cleaned up as part of the request workflow.
+        outfile = file.temp(cleanup=false, "openmpt", ".wav")
+        try
+          let {status = {code}} =
+            process.run(
+              "#{binary} --assume-terminal --quiet --force #{options} --output #{
+                process.quote(outfile)
+              } #{process.quote(infile)}"
+            )
+          code == 0 ? "#{prefix}#{outfile}" : null
+        catch err do
+          file.remove(outfile)
+          rlog(
+            "Error while decoding #{infile} using ffmpeg: #{err}"
+          )
+          null
+        end
+      end
+  )
+end
+
+# Standard function for displaying metadata.
+# Shows artist and title, using "Unknown" when a field is empty.
+# @param m Metadata packet to be displayed.
+# @category String
+def string_of_metadata(m) =
+  artist = m["artist"]
+  title = m["title"]
+  artist = if "" == artist then "Unknown" else artist end
+  title = if "" == title then "Unknown" else title end
+  "#{artist} -- #{title}"
+end
+
+# Use X On Screen Display to display metadata info.
+# @flag extra
+# @param ~color    Color of the text.
+# @param ~position Position of the text (top|middle|bottom).
+# @param ~font     Font used (xfontsel is your friend...)
+# @param ~display  Function used to display a metadata packet.
+# @category Source / Track processing
+def osd_metadata(
+  ~color="green",
+  ~position="top",
+  ~font="-*-courier-*-r-*-*-*-240-*-*-*-*-*-*",
+  ~display=string_of_metadata,
+  s
+) =
+  osd =
+    'osd_cat -p #{position} --font #{process.quote(font)}' ^
+      ' --color #{color}'
+
+  def feedback(m) =
+    ignore(
+      process.run(
+        "echo #{process.quote(display(m))} | #{osd} &"
+      )
+    )
+  end
+
+  s.on_metadata(synchronous=false, feedback)
+end
+
+# Use notify to display metadata info.
+# @flag extra
+# @param ~urgency Urgency (low|normal|critical).
+# @param ~icon    Icon filename or stock icon to display.
+# @param ~timeout Timeout in seconds.
+# @param ~display Function used to display a metadata packet.
+# @param ~title   Title of the notification message.
+# @category Source / Track processing
+def notify_metadata(
+  ~urgency="low",
+  ~icon="stock_smiley-22",
+  ~timeout=3.,
+  ~display=string_of_metadata,
+  ~title="Liquidsoap: new track",
+  s
+) =
+  time = int_of_float(timeout * 1000.)
+  send =
+    'notify-send -i #{icon} -u #{urgency}' ^
+      ' -t #{time} #{process.quote(title)} '
+
+  s.on_metadata(
+    synchronous=false,
+    fun (m) -> ignore(process.run(send ^ process.quote(display(m))))
+  )
+end

--- a/tests/liq/extra/fades.liq
+++ b/tests/liq/extra/fades.liq
@@ -1,0 +1,260 @@
+# Plot the first crossfade transition. Used for visualizing and testing
+# crossfade transitions.
+# @category Source / Track processing
+# @flag extra
+def cross.plot(~png=null, ~dir=null, ~font=null, ~font_size=10, s) =
+  dir =
+    if
+      null.defined(dir)
+    then
+      null.get(dir)
+    else
+      dir = file.temp_dir("plot")
+      on_cleanup({file.rmdir(dir)})
+      dir
+    end
+
+  old_txt = path.concat(dir, "old.txt")
+  new_txt = path.concat(dir, "new.txt")
+
+  def gnuplot_cmd(filename) =
+    term =
+      if
+        null.defined(font)
+      then
+        'pngcairo font "#{null.get(font)},#{font_size}"'
+      else
+        "png"
+      end
+    'set term #{term}; set output "#{(filename : string)}"; plot "#{new_txt}" \
+     using 1:2 with lines title "new track", "#{old_txt}" using 1:2 with lines \
+     title "old track"'
+  end
+
+  def store_rms(~id, s) =
+    s = rms(duration=settings.frame.duration(), s)
+    t0 = ref(null)
+
+    s.on_frame(
+      synchronous=true,
+      before=false,
+      {
+        let t0 =
+          if
+            null.defined(t0())
+          then
+            null.get(t0())
+          else
+            t0 := source.time(s)
+            null.get(t0())
+          end
+        let v = float.truncate(digits=4, mode="floor", s.rms())
+        let p = float.truncate(digits=4, mode="floor", source.time(s) - t0)
+        fname = id == "old" ? old_txt : new_txt
+        file.write(append=true, data="#{p}\t#{v}\n", fname)
+      }
+    )
+
+    s
+  end
+
+  plotted = ref(false)
+
+  def transition(old, new) =
+    old = store_rms(id="old", fade.out(old.source))
+    new = store_rms(id="new", fade.in(new.source))
+
+    s = blank(duration=0.1)
+    s.on_frame(
+      synchronous=true,
+      {
+        if
+          null.defined(png) and not plotted()
+        then
+          ignore(
+            process.run(
+              "gnuplot -e #{process.quote(gnuplot_cmd(null.get(png)))}"
+            )
+          )
+        end
+        plotted := true
+      }
+    )
+
+    sequence(single_track=false, [add(normalize=false, [new, old]), once(s)])
+  end
+
+  cross(transition, s)
+end
+
+# Plot two sine tracks with given autocue params.
+# Used for visualizing and testing autocue crossfade transitions.
+# @category Source / Track processing
+# @flag extra
+def autocue.plot(
+  ~png=null,
+  ~dir=null,
+  ~font=null,
+  ~font_size=10,
+  ~old_autocue,
+  ~new_autocue,
+  ~sync="auto",
+  ~on_stop
+) =
+  dir =
+    if
+      null.defined(dir)
+    then
+      null.get(dir)
+    else
+      dir = file.temp_dir("plot")
+      on_cleanup({file.rmdir(dir)})
+      dir
+    end
+
+  old_txt = path.concat(dir, "old.txt")
+  new_txt = path.concat(dir, "new.txt")
+
+  def gnuplot_cmd(filename) =
+    term =
+      if
+        null.defined(font)
+      then
+        'pngcairo font "#{null.get(font)},#{font_size}"'
+      else
+        "png"
+      end
+    'set term #{term}; set output "#{(filename : string)}"; plot "#{new_txt}" \
+     using 1:2 with lines title "new track", "#{old_txt}" using 1:2 with lines \
+     title "old track"'
+  end
+
+  def autocue_annotate(a, uri) =
+    meta = autocue.metadata(implementation="autocue.plot", a)
+    meta =
+      list.map(fun ((label, value)) -> "#{label}=#{string.quote(value)}", meta)
+    meta = string.concat(separator=",", meta)
+    "annotate:#{meta}:#{uri}"
+  end
+
+  old_uri =
+    process.uri(
+      extname="wav",
+      "ffmpeg -f lavfi -i \"sine=frequency=1000:duration=10\" -y $(output) < \
+       /dev/null"
+    )
+  old_uri = autocue_annotate(old_autocue, old_uri)
+  old_source = request.once(request.create(old_uri))
+
+  new_uri =
+    process.uri(
+      extname="wav",
+      "ffmpeg -f lavfi -i \"sine=frequency=500:duration=10\" -y $(output) < \
+       /dev/null"
+    )
+  new_uri = autocue_annotate(new_autocue, new_uri)
+  new_source = request.once(request.create(new_uri))
+
+  s = sequence([old_source, new_source])
+
+  def store_rms(~fname, s) =
+    s = rms(duration=settings.frame.duration(), s)
+    t0 = ref(null)
+
+    s.on_frame(
+      synchronous=true,
+      before=false,
+      {
+        let t0 =
+          if
+            null.defined(t0())
+          then
+            null.get(t0())
+          else
+            t0 := source.time(s)
+            null.get(t0())
+          end
+        let t = float.truncate(digits=4, mode="floor", source.time(s) - t0)
+        let v = float.truncate(digits=4, mode="floor", s.rms())
+        file.write(append=true, data="#{t}\t#{v}\n", fname)
+      }
+    )
+
+    s
+  end
+
+  is_first_ending = ref(true)
+  is_first_starting = ref(true)
+
+  def transition(old, new) =
+    list.iter(
+      fun (x) ->
+        log(
+          level=4,
+          "Before: #{x}"
+        ),
+      old.metadata
+    )
+
+    list.iter(
+      fun (x) ->
+        log(
+          level=4,
+          "After : #{x}"
+        ),
+      new.metadata
+    )
+
+    def ending_map(s) =
+      if
+        is_first_ending()
+      then
+        is_first_ending := false
+        store_rms(fname=old_txt, s)
+      else
+        s
+      end
+    end
+
+    def starting_map(s) =
+      if
+        is_first_starting()
+      then
+        is_first_starting := false
+        store_rms(fname=new_txt, s)
+      else
+        s
+      end
+    end
+
+    cross.simple(
+      initial_fade_in_metadata=new.metadata,
+      initial_fade_out_metadata=old.metadata,
+      ending_map=ending_map,
+      starting_map=starting_map,
+      old.source,
+      new.source
+    )
+  end
+
+  s = cross(transition, s)
+
+  clock.assign_new(sync=sync, [s])
+
+  def on_stop() =
+    if
+      null.defined(png)
+    then
+      ignore(
+        process.run(
+          "gnuplot -e #{process.quote(gnuplot_cmd(null.get(png)))}"
+        )
+      )
+    end
+    on_stop()
+    clock(s.clock).stop()
+  end
+
+  o = output.dummy(fallible=true, s)
+  o.on_stop(synchronous=true, on_stop)
+end

--- a/tests/liq/extra/file.liq
+++ b/tests/liq/extra/file.liq
@@ -1,0 +1,66 @@
+# Keep a record of played files. This is primarily useful to know when a song
+# was last played and avoid repetitions.
+# @flag extra
+# @param ~duration Duration (in seconds) after which songs are forgotten. By default, songs are not forgotten which means that the playlog will contain all the songs ever played.
+# @param ~hash Function to extract an identifier from the metadata. By default, the filename is used but we could return the artist to know when a song from a given artist was last played for instance.
+# @param ~persistency Set a file name where the values are stored and loaded in case the script is restarted.
+# @category Source / Track processing
+# @method add Record that file with given metadata has been played.
+# @method last How long ago a file was played (in seconds), `infinity` is returned if the song has never been played.
+def playlog(
+  ~duration=infinity,
+  ~persistency=null,
+  ~hash=fun (m) -> m["filename"]
+) =
+  l = ref([])
+
+  # Load from persistency file
+  if
+    null.defined(persistency)
+  then
+    if
+      file.exists(null.get(persistency))
+    then
+      let json.parse (parsed : [(string * float)]?) =
+        file.contents(null.get(persistency))
+
+      if null.defined(parsed) then l := null.get(parsed) end
+    end
+  end
+
+  # Save into persistency file
+  def save() =
+    if
+      null.defined(persistency)
+    then
+      data = json.stringify(l())
+      file.write(data=data, null.get(persistency))
+    end
+  end
+
+  # Remove too old elements
+  def prune() =
+    if
+      duration != infinity
+    then
+      t = time()
+      l := list.assoc.filter(fun (_, tf) -> t - tf <= duration, l())
+    end
+  end
+
+  # Add a new entry
+  def add(m) =
+    prune()
+    f = hash(m)
+    l := (f, time())::l()
+    save()
+  end
+
+  # Last time this entry was played
+  def last(m) =
+    f = hash(m)
+    time() - list.assoc(default=0. - infinity, f, l())
+  end
+
+  {add = add, last = last}
+end

--- a/tests/liq/extra/http.liq
+++ b/tests/liq/extra/http.liq
@@ -1,0 +1,160 @@
+# Harbor middleware to add CORS headers
+# @category Internet
+# @flag extra
+# @param ~origin Configures the Access-Control-Allow-Origin CORS header
+# @param ~origin_callback Origin callback for advanced uses. If passed, overrides `origin` argument. Takes the request as input and returns the allowed origin. Return `null` to skip all CORS headers.
+# @param ~methods Configures the Access-Control-Allow-Methods CORS header.
+# @param ~allowed_headers Configures the Access-Control-Allow-Headers CORS header. If not specified, defaults to reflecting the headers specified in the request's Access-Control-Request-Headers header.
+# @param ~exposed_headers Configures the Access-Control-Expose-Headers CORS header. If not specified, no custom headers are exposed.
+# @param ~credentials Configures the Access-Control-Allow-Credentials CORS header. Set to true to pass the header, otherwise it is omitted.
+# @param ~max_age Configures the Access-Control-Max-Age CORS header. Set to an integer to pass the header, otherwise it is omitted.
+# @param ~preflight_continue Pass the CORS preflight response to the nexnhandler.
+# @param ~options_status_code Provides a status code to use for successful OPTIONS requests, since some legacy browsers (IE11, various SmartTVs) choke on 204.
+def harbor.http.middleware.cors(
+  ~origin=null("*"),
+  ~origin_callback=null,
+  ~methods=["GET", "HEAD", "PUT", "PATCH", "POST", "DELETE"],
+  ~allowed_headers=null,
+  ~exposed_headers=[],
+  ~credentials=false,
+  ~max_age=null,
+  ~preflight_continue=false,
+  ~options_status_code=204
+) =
+  fun (req, res, next) ->
+    begin
+      # This is for typing purposes
+      res = if false then http.response() else res end
+      if
+        false
+      then
+        harbor.http.register(
+          "/foo",
+          fun (r, _) -> ignore(if false then r else req end)
+        )
+      end
+
+      vary = ref([])
+
+      def add_vary() =
+        if
+          vary() != []
+        then
+          res.header("Vary", string.concat(separator=",", vary()))
+        end
+      end
+
+      def vary(v) =
+        vary := v::vary()
+      end
+
+      def add_origin(origin) =
+        res.header("Access-Control-Allow-Origin", origin)
+        if origin != "*" then vary("Origin") end
+      end
+
+      def add_methods() =
+        if
+          methods != []
+        then
+          res.header(
+            "Access-Control-Allow-Methods",
+            string.concat(separator=",", methods)
+          )
+        end
+      end
+
+      def add_credentials() =
+        if
+          credentials
+        then
+          res.header("Access-Control-Allow-Credentials", "true")
+        end
+      end
+
+      def add_allowed_headers() =
+        allowed_headers =
+          if
+            null.defined(allowed_headers)
+          then
+            string.concat(separator=",", null.get(allowed_headers))
+          elsif
+            list.assoc.mem("access-control-request-headers", req.headers)
+          then
+            req.headers["access-control-request-headers"]
+          else
+            null
+          end
+
+        if
+          null.defined(allowed_headers)
+        then
+          res.header("Access-Control-Allow-Headers", null.get(allowed_headers))
+          vary("Access-Control-Request-Headers")
+        end
+      end
+
+      def add_exposed_headers() =
+        if
+          exposed_headers != []
+        then
+          res.header(
+            "Access-Control-Expose-Headers",
+            string.concat(separator=",", exposed_headers)
+          )
+        end
+      end
+
+      def add_max_age() =
+        if
+          null.defined(max_age)
+        then
+          res.header("Access-Control-Max-Age", "#{(null.get(max_age) : int)}")
+        end
+      end
+
+      origin =
+        if
+          null.defined(origin_callback)
+        then
+          fn = null.get(origin_callback)
+          fn(req)
+        else
+          getter.get(origin)
+        end
+
+      if
+        not null.defined(origin)
+      then
+        next(req, res)
+      else
+        add_origin(null.get(origin))
+        if
+          req.method == "OPTIONS"
+        then
+          add_credentials()
+          add_methods()
+          add_allowed_headers()
+          add_max_age()
+          add_exposed_headers()
+          add_vary()
+          if
+            preflight_continue
+          then
+            next(req, res)
+          else
+            res.status_code(options_status_code)
+            res.header("Content-length", "0")
+          end
+        else
+          add_credentials()
+          add_allowed_headers()
+          add_vary()
+          next(req, res)
+        end
+      end
+    end
+end
+
+# This is for typing purposes
+if false then harbor.http.middleware.register(harbor.http.middleware.cors()) end

--- a/tests/liq/extra/interactive.liq
+++ b/tests/liq/extra/interactive.liq
@@ -1,0 +1,917 @@
+# Information about all variables
+# @category Interaction
+variables = ref([])
+
+# Float variables
+# @category Interaction
+variables_float = ref([])
+
+# Int variables
+# @category Interaction
+variables_int = ref([])
+
+# Bool variables
+# @category Interaction
+variables_bool = ref([])
+
+# String variables
+# @category Interaction
+variables_string = ref([])
+
+# Unit variables: those are not references but handler functions
+# @category Interaction
+variables_unit = ref([])
+let interactive = ()
+let interactive.float = ()
+let interactive.int = ()
+let interactive.bool = ()
+let interactive.string = ()
+let interactive.unit = ()
+let interactive.error = error.register("interactive.error")
+
+# @flag hidden
+def interactive.list(_) =
+  l = variables()
+  l =
+    list.map(
+      fun (xv) ->
+        begin
+          let (x, v) = xv
+          "#{x} : #{v.type}"
+        end,
+      l
+    )
+
+  string.concat(separator="\n", l)
+end
+
+server.register(
+  usage="list",
+  description="List available interactive variables.",
+  namespace="var",
+  "list",
+  interactive.list
+)
+
+# Description of an interactive variable.
+# @flag hidden
+def interactive.description(name) =
+  list.assoc(name, variables()).description
+end
+
+# Type of an interactive variable.
+# @flag hidden
+def interactive.type(name) =
+  list.assoc(name, variables()).type
+end
+
+# @flag hidden
+def interactive.float.ref(name) =
+  list.assoc(name, variables_float()).ref
+end
+
+# @flag hidden
+def interactive.int.ref(name) =
+  list.assoc(name, variables_int()).ref
+end
+
+# @flag hidden
+def interactive.bool.ref(name) =
+  list.assoc(name, variables_bool()).ref
+end
+
+# @flag hidden
+def interactive.string.ref(name) =
+  list.assoc(name, variables_string()).ref
+end
+
+# @flag hidden
+def interactive.unit.handler(name) =
+  list.assoc(name, variables_unit()).handler
+end
+
+# @flag hidden
+def interactive.remove(name) =
+  variables := list.assoc.remove.all(name, variables())
+end
+
+# Remove an interactive variable.
+# @param name Name of the variable.
+# @category Interaction
+# @flag hidden
+def interactive.float.remove(name) =
+  interactive.remove(name)
+  variables_float := list.assoc.remove.all(name, variables_float())
+end
+
+# Remove an interactive variable.
+# @param name Name of the variable.
+# @category Interaction
+# @flag hidden
+def interactive.int.remove(name) =
+  interactive.remove(name)
+  variables_int := list.assoc.remove.all(name, variables_int())
+end
+
+# Remove an interactive variable.
+# @param name Name of the variable.
+# @category Interaction
+# @flag hidden
+def interactive.bool.remove(name) =
+  interactive.remove(name)
+  variables_bool := list.assoc.remove.all(name, variables_bool())
+end
+
+# Remove an interactive variable.
+# @param name Name of the variable.
+# @category Interaction
+# @flag hidden
+def interactive.string.remove(name) =
+  interactive.remove(name)
+  variables_string := list.assoc.remove.all(name, variables_string())
+end
+
+# Remove an interactive variable.
+# @param name Name of the variable.
+# @category Interaction
+# @flag hidden
+def interactive.unit.remove(name) =
+  interactive.remove(name)
+  variables_unit := list.assoc.remove.all(name, variables_unit())
+end
+
+# Function called to ensure persistency of data.
+# @category Interaction
+let interactive.persistency = ref(fun () -> ())
+
+# @flag hidden
+def interactive.float.set(name, v) =
+  interactive.float.ref(name) := v
+  p = interactive.persistency()
+  p()
+end
+
+# @flag hidden
+def interactive.int.set(name, v) =
+  interactive.int.ref(name) := v
+  p = interactive.persistency()
+  p()
+end
+
+# @flag hidden
+def interactive.bool.set(name, v) =
+  interactive.bool.ref(name) := v
+  p = interactive.persistency()
+  p()
+end
+
+# @flag hidden
+def interactive.string.set(name, v) =
+  interactive.string.ref(name) := v
+  p = interactive.persistency()
+  p()
+end
+
+# @flag hidden
+def interactive.unit.set(name) =
+  f = interactive.unit.handler(name)
+  f()
+end
+
+%ifdef osc.on_float
+let stdlib_osc = osc
+%endif
+
+# Create an interactive variable.
+# @flag hidden
+# @param ~name Name of the variable.
+# @param ~description Description of the variable.
+# @param ~osc OSC address for the variable.
+# @param ~type Type of the variable.
+def interactive.create(~name, ~description="", ~osc="", ~type) =
+  if
+    list.assoc.mem(name, variables())
+  then
+    error.raise(
+      interactive.error,
+      "variable already registered"
+    )
+  end
+
+  variables := (name, {type = type, description = description})::variables()
+  variables :=
+    list.sort(
+      fun (n, n') -> if fst(n) < fst(n') then -1 else 1 end,
+      variables()
+    )
+
+%ifdef osc.on_float
+  if
+    osc != ""
+  then
+    if
+      type == "float"
+    then
+      stdlib_osc.on_float(osc, fun (x) -> interactive.float.set(name, x))
+    elsif
+      type == "int"
+    then
+      stdlib_osc.on_int(osc, fun (x) -> interactive.int.set(name, x))
+    elsif
+      type == "bool"
+    then
+      stdlib_osc.on_bool(osc, fun (x) -> interactive.bool.set(name, x))
+    elsif
+      type == "string"
+    then
+      stdlib_osc.on_string(osc, fun (x) -> interactive.string.set(name, x))
+    elsif
+      type == "unit"
+    then
+      ()
+    else
+      # TODO
+      error.raise(error.not_found)
+    end
+  end
+%else
+  ignore(osc)
+%endif
+end
+
+# @flag hidden
+def interactive.get(name) =
+  try
+    t = interactive.type(name)
+    if
+      t == "float"
+    then
+      r = interactive.float.ref(name)
+      string.float(decimal_places=3, r())
+    elsif
+      t == "int"
+    then
+      r = interactive.int.ref(name)
+      string(r())
+    elsif
+      t == "bool"
+    then
+      r = interactive.bool.ref(name)
+      string(r())
+    elsif
+      t == "string"
+    then
+      r = interactive.string.ref(name)
+      r()
+    elsif
+      t == "unit"
+    then
+      "()"
+    else
+      error.raise(error.not_found)
+    end
+  catch _ do
+    "Variable not found."
+  end
+end
+
+server.register(
+  namespace="var",
+  description="Get the value of a variable.",
+  "get",
+  interactive.get
+)
+
+# @flag hidden
+def interactive.set(arg) =
+  try
+    arg = r/=/.split(arg)
+    name = string.trim(list.nth(arg, 0))
+    value = string.trim(list.nth(arg, 1))
+    t = interactive.type(name)
+    if
+      t == "float"
+    then
+      interactive.float.set(name, float_of_string(value))
+    elsif
+      t == "int"
+    then
+      interactive.int.set(name, int_of_string(value))
+    elsif
+      t == "bool"
+    then
+      interactive.bool.set(name, bool_of_string(value))
+    elsif
+      t == "string"
+    then
+      interactive.string.set(name, value)
+    elsif
+      t == "unit"
+    then
+      interactive.unit.set(name)
+    else
+      error.raise(error.not_found)
+    end
+
+    "Variable #{name} set."
+  catch _ do
+    "Syntax error or variable not found."
+  end
+end
+
+server.register(
+  usage="set <name> = <value>",
+  description="Set the value of a variable.",
+  namespace="var",
+  "set",
+  interactive.set
+)
+
+# Save the value of all interactive variables in a file.
+# @category Interaction
+# @flag extra
+# @param fname Name of the file.
+def interactive.save(fname) =
+  data =
+    json.stringify(
+      {
+        float =
+          list.map(
+            fun (nv) ->
+              begin
+                let (name, v) = nv
+                (name, v.ref())
+              end,
+            variables_float()
+          ),
+        int =
+          list.map(
+            fun (nv) ->
+              begin
+                let (name, v) = nv
+                (name, v.ref())
+              end,
+            variables_int()
+          ),
+        bool =
+          list.map(
+            fun (nv) ->
+              begin
+                let (name, v) = nv
+                (name, v.ref())
+              end,
+            variables_bool()
+          ),
+        string =
+          list.map(
+            fun (nv) ->
+              begin
+                let (name, v) = nv
+                (name, v.ref())
+              end,
+            variables_string()
+          )
+      }
+    )
+
+  file.write(data=data, fname)
+end
+
+# Load the value of interactive variables from a file.
+# @category Interaction
+# @flag extra
+# @param fname Name of the file.
+def interactive.load(fname) =
+  vars = file.contents(fname)
+  let json.parse (vars :
+    {
+      float: [(string * float)],
+      int: [(string * int)],
+      bool: [(string * bool)],
+      string: [(string * string)]
+    }
+  ) = vars
+
+  list.iter(
+    fun (nv) ->
+      try
+        interactive.float.set(fst(nv), snd(nv))
+      catch _ do
+        log.important(
+          label="interactive.load",
+          "Variable #{fst(nv)} not found."
+        )
+      end,
+    vars.float
+  )
+
+  list.iter(
+    fun (nv) ->
+      try
+        interactive.int.set(fst(nv), snd(nv))
+      catch _ do
+        log.important(
+          label="interactive.load",
+          "Variable #{fst(nv)} not found."
+        )
+      end,
+    vars.int
+  )
+
+  list.iter(
+    fun (nv) ->
+      try
+        interactive.bool.set(fst(nv), snd(nv))
+      catch _ do
+        log.important(
+          label="interactive.load",
+          "Variable #{fst(nv)} not found."
+        )
+      end,
+    vars.bool
+  )
+
+  list.iter(
+    fun (nv) ->
+      try
+        interactive.string.set(fst(nv), snd(nv))
+      catch _ do
+        log.important(
+          label="interactive.load",
+          "Variable #{fst(nv)} not found."
+        )
+      end,
+    vars.string
+  )
+end
+
+# Make the value of interactive variables persistent: they are loaded from the
+# given file and stored there whenever updated. This function should be called
+# after all interactive variables have been defined (variables not declared yet
+# will not be loaded).
+# @category Interaction
+# @flag extra
+# @param fname Name of the file.
+def interactive.persistent(fname) =
+  if
+    file.exists(fname)
+  then
+    interactive.load(fname)
+  else
+    interactive.save(fname)
+  end
+
+  interactive.persistency := {interactive.save(fname)}
+end
+
+# Expose interactive variables through harbor http server. Once this is called,
+# with default parameters, you can browse <http://localhost:8000/interactive> to
+# change the value of interactive variables using sliders.
+# @category Interaction
+# @flag extra
+# @param ~port Port of the server.
+# @param ~transport Http transport. Use `http.transport.ssl` or http.transport.secure_transport`, when available, to enable HTTPS output
+# @param ~uri URI of the server.
+def interactive.harbor(
+  ~transport=http.transport.unix,
+  ~port=8000,
+  ~uri="/interactive"
+) =
+  def webpage(request, response) =
+    form_data = request.data
+    data = ref("")
+
+    def add(s) =
+      data := data() ^ s ^ "\n"
+    end
+
+    title =
+      "Interactive values"
+    add(
+      "<!DOCTYPE html><html><head>"
+    )
+    add(
+      "<meta charset='utf-8'/>"
+    )
+    add("<title>#{title}</title>")
+    add(
+      "<style>
+    body {
+      font-family: sans-serif;
+    }
+    h1 {
+      text-align: center;
+    }
+    form {
+      border-radius: 20px;
+      display: block;
+      background-color: whitesmoke;
+      width: max-content;
+      margin: 0 auto;
+      padding: 2ex;
+      display:grid;
+      grid-template-columns: max-content max-content;
+      grid-gap: 5px;
+    }
+    label {
+      text-align: right;
+    }
+    input {
+      width: 300px;
+    }
+    </style>"
+    )
+
+    # TODO: we could send only the updated value instead of sending them all
+    add(
+      "<script>
+    function send() {
+      let interactive = document.getElementsByClassName('interactive');
+      let data = '';
+      for(var i=0; i<interactive.length; i++){
+        if (interactive[i].type == 'checkbox') {
+          if (interactive[i].checked) {
+            interactive[i].value = 'true'
+          } else {
+            interactive[i].value = 'false'
+          }
+        }
+        if (interactive[i].type != 'button') {
+          data = data.concat(interactive[i].name+'='+encodeURIComponent(interactive[i].value))+(i < interactive.length - 1 ? '&' : '')
+        }
+      }
+      console.log('Posting: ' + data);
+      let xmlHttp = new XMLHttpRequest();
+      xmlHttp.open('POST', '#{
+        uri
+      }');
+      xmlHttp.onreadystatechange = function () {
+        if(xmlHttp.readyState === XMLHttpRequest.DONE) {
+          var status = xmlHttp.status;
+          if (status === 0 || (status >= 200 && status < 400)) {
+            //console.log(xmlHttp.responseText);
+          } else {
+            console.log('Failed to send values.')
+          }
+        }
+      }
+      xmlHttp.send(data);
+    }
+    function sendUnit(name) {
+      const body = name + '=';
+      console.log('Posting: ' + body);
+      fetch('#{
+        uri
+      }', {method: 'POST', body: body});
+    }
+    </script>"
+    )
+
+    add("</head><body>")
+    add("<h1>#{title}</h1>")
+
+    def add_var((name, v)) =
+      description = interactive.description(name)
+      description =
+        if
+          description == ""
+        then
+          name
+        else
+          "#{description} (#{name})"
+        end
+
+      add(
+        "<label for=#{name}>#{string.escape.html(description)}</label>"
+      )
+      common =
+        "id='#{name}' name='#{name}' class='interactive' onchange=\"send()\""
+
+      if
+        v.type == "float"
+      then
+        v = list.assoc(name, variables_float())
+        value = http.string_of_float(v.ref())
+        if
+          v.min == 0. - infinity or v.max == infinity
+        then
+          add(
+            "<input type='number' #{common} step='#{v.step}' value='#{value}'>"
+          )
+        else
+          min = http.string_of_float(v.min)
+          max = http.string_of_float(v.max)
+          step = http.string_of_float(v.step)
+          value = http.string_of_float(v.ref())
+          unit =
+            if
+              v.unit == ""
+            then
+              ""
+            else
+              " " ^
+                v.unit
+            end
+          add(
+            "<div><input type='range' #{common} min='#{min}' max='#{max}' step='#{
+              step
+            }' value='#{value}' oninput='document.getElementById(\"#{
+              name
+            }-value\").innerHTML = this.value+\"#{unit}\"'><text id='#{
+              name
+            }-value' style='inline'>#{value}#{unit}</text></div>"
+          )
+        end
+      elsif
+        v.type == "int"
+      then
+        v = list.assoc(name, variables_int())
+        value = string(v.ref())
+        add(
+          "<input type='number' #{common} step='1' value='#{value}'>"
+        )
+      elsif
+        v.type == "bool"
+      then
+        v = list.assoc(name, variables_bool())
+        c = (v.ref()) ? "checked" : ""
+        add(
+          "<input type='checkbox' #{common} value='true' #{c}>"
+        )
+      elsif
+        v.type == "string"
+      then
+        v = list.assoc(name, variables_string())
+        add(
+          "<input type='text' #{common} value='#{string.escape.html(v.ref())}'>"
+        )
+      elsif
+        v.type == "unit"
+      then
+        add(
+          "<button type='button' #{common} onclick=\"sendUnit('#{name}')\">#{
+            name
+          }</button>"
+        )
+      else
+        ()
+      end
+    end
+
+    add("<form>")
+    list.iter(add_var, variables())
+    add("</form>")
+    add("</body>")
+    response.html(data())
+  end
+
+  harbor.http.register(
+    transport=transport,
+    port=port,
+    method="GET",
+    uri,
+    webpage
+  )
+
+  def setter(request, _) =
+    data = url.split_args(request.body())
+
+    def update((name, v)) =
+      try
+        t = interactive.type(name)
+        if
+          t == "float"
+        then
+          interactive.float.set(name, float_of_string(v))
+        elsif
+          t == "int"
+        then
+          interactive.int.set(name, int_of_string(v))
+        elsif
+          t == "bool"
+        then
+          interactive.bool.set(name, bool_of_string(v))
+        elsif
+          t == "string"
+        then
+          interactive.string.set(name, v)
+        elsif
+          t == "unit"
+        then
+          interactive.unit.set(name)
+        end
+      catch e do
+        log.important(
+          label="interactive.harbor",
+          "Could not update variable #{name} (#{e.kind}: #{e.message})."
+        )
+      end
+    end
+
+    list.iter(update, data)
+  end
+
+  harbor.http.register(
+    transport=transport,
+    port=port,
+    method="POST",
+    uri,
+    setter
+  )
+
+  log.important(
+    label="interactive.harbor",
+    "Website should be ready at <http://localhost:#{port}#{uri}>."
+  )
+end
+
+# Read a float from an interactive input.
+# @category Interaction
+# @flag extra
+# @param ~min Minimal value.
+# @param ~max Maximal value.
+# @param ~step Typical variation of the value.
+# @param ~description Description of the variable.
+# @param ~unit Unit for the variable.
+# @param ~osc OSC address.
+# @param name Name of the variable.
+# @param v Initial value.
+def replaces interactive.float(
+  ~min=0. - infinity,
+  ~max=infinity,
+  ~step=0.1,
+  ~description="",
+  ~unit="",
+  ~osc="",
+  name,
+  v
+) =
+  interactive.create(name=name, description=description, osc=osc, type="float")
+  r = ref(v)
+  variables_float :=
+    (
+      name,
+      {ref = r, unit = unit, min = min, max = max, step = step}
+    )::variables_float()
+
+  r.{
+    set = fun (x) -> interactive.float.set(name, x),
+    remove = {interactive.float.remove(name)}
+  }
+end
+
+# Read an integer from an interactive input.
+# @category Interaction
+# @flag extra
+# @param ~description Description of the variable.
+# @param ~osc OSC address.
+# @param name Name of the variable.
+# @param v Initial value.
+def replaces interactive.int(~description="", ~osc="", name, v) =
+  interactive.create(name=name, description=description, osc=osc, type="int")
+  r = ref(v)
+  variables_int := (name, {ref = r})::variables_int()
+  r.{
+    set = fun (x) -> interactive.int.set(name, x),
+    remove = {interactive.int.remove(name)}
+  }
+end
+
+# Read a boolean from an interactive input.
+# @category Interaction
+# @flag extra
+# @param ~description Description of the variable.
+# @param ~osc OSC address.
+# @param name Name of the variable.
+# @param v Initial value.
+def replaces interactive.bool(~description="", ~osc="", name, v) =
+  interactive.create(name=name, description=description, osc=osc, type="bool")
+  r = ref(v)
+  variables_bool := (name, {ref = r})::variables_bool()
+  r.{
+    set = fun (x) -> interactive.bool.set(name, x),
+    remove = {interactive.bool.remove(name)}
+  }
+end
+
+# Read a string from an interactive input.
+# @category Interaction
+# @flag extra
+# @param ~description Description of the variable.
+# @param ~osc OSC address.
+# @param name Name of the variable.
+# @param v Initial value.
+def replaces interactive.string(~description="", ~osc="", name, v) =
+  interactive.create(name=name, description=description, osc=osc, type="string")
+  r = ref(v)
+  variables_string := (name, {ref = r})::variables_string()
+  r.{
+    set = fun (x) -> interactive.string.set(name, x),
+    remove = {interactive.string.remove(name)}
+  }
+end
+
+# Register a callback when a unit interactive input is set.
+# @category Interaction
+# @flag extra
+# @param ~description Description of the variable.
+# @param ~osc OSC address.
+# @param name Name of the variable.
+# @param f Function triggered when the value is set.
+def replaces interactive.unit(~description="", ~osc="", name, f) =
+  interactive.create(name=name, description=description, osc=osc, type="unit")
+  variables_unit := (name, {handler = f})::variables_unit()
+  {set = f, remove = {interactive.float.remove(name)}}
+end
+
+# Create a multiband compressor whose parameters are interactive variables.
+# @category Interaction
+# @flag extra
+# @param ~id Id of the source. Variable names are prefixed with this.
+# @param ~bands Number of bands.
+# @param s Source to compress.
+def compress.multiband.interactive(~id=null, ~bands=5, s) =
+  id = string.id.default(default="compress.multiband.interactive", id)
+  prefix = id ^ "_"
+  wet = interactive.float(prefix ^ "wet", min=0., max=1., 1.)
+  min_freq = 100.
+  max_freq = 15000.
+
+  def band(i) =
+    frequency =
+      exp(
+        (ln(max_freq) - ln(min_freq)) * float_of_int(i) /
+          float_of_int(bands - 1) +
+          ln(min_freq)
+      )
+
+    log.important(
+      label=id,
+      "Adding a band at #{frequency} Hz."
+    )
+    frequency =
+      interactive.float(
+        "#{prefix}frequency#{i}",
+        unit="Hz",
+        min=0.,
+        max=20000.,
+        step=10.,
+        frequency
+      )
+
+    attack =
+      interactive.float(
+        "#{prefix}attack#{i}",
+        unit="ms",
+        min=0.,
+        max=1000.,
+        step=10.,
+        100.
+      )
+
+    release =
+      interactive.float(
+        "#{prefix}release#{i}",
+        unit="ms",
+        min=0.,
+        max=1000.,
+        step=10.,
+        200.
+      )
+
+    threshold =
+      interactive.float(
+        "#{prefix}threshold#{i}",
+        unit="dB",
+        min=-20.,
+        max=0.,
+        step=0.1,
+        -10.
+      )
+
+    ratio =
+      interactive.float("#{prefix}ratio#{i}", min=1., max=10., step=0.1, 4.)
+
+    gain =
+      interactive.float(
+        "#{prefix}gain#{i}",
+        unit="dB",
+        min=0.,
+        max=30.,
+        step=0.1,
+        3.
+      )
+
+    {
+      frequency = frequency,
+      attack = attack,
+      release = release,
+      threshold = threshold,
+      ratio = ratio,
+      gain = gain
+    }
+  end
+
+  l = list.init(bands, band)
+  compress.multiband(wet=wet, s, l)
+end

--- a/tests/liq/extra/metadata.liq
+++ b/tests/liq/extra/metadata.liq
@@ -1,0 +1,75 @@
+# Store and retrieve file covers using metadata. This returns a set of
+# getter/setter methods that can be used to store and retrieve cover art.
+# Typical usage is to set cover art in a `on_metadata` handler and retrieve
+# it in a `video.add_image` operator. See `video.add_cover` for an implementation
+# example.
+# @category Metadata
+# @flag extra
+# @param ~default Default cover file when no cover is available
+# @param ~mime_types Recognized mime types and their corresponding file extensions.
+def file.cover.manager(
+  ~id=null,
+  ~mime_types=[
+    ("image/gif", "gif"),
+    ("image/jpg", "jpeg"),
+    ("image/jpeg", "jpeg"),
+    ("image/png", "png"),
+    ("image/webp", "webp")
+  ],
+  ~default
+) =
+  id = string.id.default(id, default="cover")
+  default = request.create(persistent=true, default)
+
+  current_cover_request = ref(default)
+
+  def extract_cover_from_metadata(_metadata) =
+    filename = _metadata["filename"]
+    log.info(
+      label=id,
+      "Extracting cover from #{string.quote(filename)}."
+    )
+    cover = metadata.cover(_metadata)
+
+    new_cover =
+      if
+        not null.defined(cover)
+      then
+        log.important(
+          label=id,
+          "File #{string.quote(filename)} has no cover."
+        )
+        null
+      else
+        cover = null.get(cover)
+        extension = mime_types[cover.mime]
+        if
+          extension == ""
+        then
+          log.important(
+            label=id,
+            "File #{string.quote(filename)} has unknown mime type #{
+              string.quote(cover.mime)
+            }."
+          )
+          null
+        else
+          cover_file = file.temp("#{id}_", ".#{extension}")
+          file.write(cover_file, data=cover)
+
+          log.important(
+            label=id,
+            "Cover for #{string.quote(filename)} saved to #{
+              string.quote(cover_file)
+            }."
+          )
+
+          request.create(temporary=true, cover_file)
+        end
+      end
+
+    current_cover_request := (new_cover ?? default)
+  end
+
+  current_cover_request.{set = extract_cover_from_metadata}
+end

--- a/tests/liq/extra/native.liq
+++ b/tests/liq/extra/native.liq
@@ -1,0 +1,201 @@
+# Native reimplementation of track functions.
+# @category Source / Track processing
+let native = ()
+
+# Create a source that plays only one track of the input source.
+# @category Source / Track processing
+# @flag extra
+def native.once(s) =
+  # source.available(track_sensitive=true, s, predicate.first({true}))
+  a = ref(true)
+  s.on_track(synchronous=true, fun (_) -> a := false)
+  source.available(s, a)
+end
+
+# At the beginning of each track, select the first ready child.
+# @category Source / Track processing
+# @flag extra
+# @param ~id Force the value of the source ID.
+# @param ~track_sensitive Re-select only on end of tracks.
+def native.fallback(~id=null, ~track_sensitive=true, sources) =
+  fail = (source.fail() : source)
+
+  def s() =
+    list.find(default=fail, source.is_ready, getter.get(sources))
+  end
+
+  infallible =
+    getter.is_constant(sources)
+    and not (list.exists(source.fallible, getter.get(sources)))
+
+  source.dynamic(
+    id=id,
+    infallible=infallible,
+    track_sensitive=track_sensitive,
+    s
+  )
+end
+
+# Play only one track of every successive source, except for the last one which
+# is played as much as available.
+# @category Source / Track processing
+# @flag extra
+# @param ~id Force the value of the source ID.
+# @param sources List of sources to play tracks from.
+def native.sequence(~id=null, sources) =
+  len = list.length(sources)
+  n = ref(0)
+  fail = source.fail()
+
+  def rec s() =
+    sn = list.nth(default=list.last(default=fail, sources), sources, n())
+    if
+      source.is_ready(sn) or n() >= len - 1
+    then
+      sn
+    else
+      ref.incr(n)
+      s()
+    end
+  end
+
+  infallible = not source.fallible(list.last(default=fail, sources))
+  s = source.dynamic(id=id, infallible=infallible, track_sensitive=true, s)
+  first = ref(true)
+
+  def ot(_) =
+    # Drop the first track
+    if first() then first := false else ref.incr(n) end
+  end
+
+  s.on_track(synchronous=true, ot)
+  s
+end
+
+# Select the first source whose predicate is true in a list. If the second
+# argument is a getter, the source will be dynamically created.
+# @category Source / Track processing
+# @flag extra
+# @param ~id Force the value of the source ID.
+# @param ~track_sensitive Re-select only on end of tracks.
+# @param sources Sources with the predicate telling when they can be played.
+def native.switch(~id=null, ~track_sensitive=true, sources) =
+  sources = list.map(fun (ps) -> source.available(snd(ps), fst(ps)), sources)
+  native.fallback(id=id, track_sensitive=track_sensitive, sources)
+end
+
+# This allows doing `open native`
+# @category Source / Track processing
+let native.request = request
+
+# @docof request.dynamic
+def native.request.dynamic(%argsof(request.dynamic), f) =
+  ignore(available)
+  ignore(timeout)
+  ignore(native)
+  ignore(synchronous)
+
+  def f() =
+    try
+      f()
+    catch _ do
+      null
+    end
+  end
+
+  # Prepared requests
+  queue = ref([])
+
+  def get_queue() =
+    def get_request(s) =
+      s.request
+    end
+
+    list.map(get_request, queue())
+  end
+
+  def add(r) =
+    s = request.once(r)
+    if
+      s.resolve()
+    then
+      queue := [...queue(), s]
+      true
+    else
+      false
+    end
+  end
+
+  def set_queue(l) =
+    queue := []
+    list.iter(fun (r) -> ignore(add(r)), l)
+  end
+
+  current = ref(null)
+
+  def get_current() =
+    if
+      null.defined(current())
+    then
+      s = null.get(current())
+      s.request
+    else
+      null
+    end
+  end
+
+  # Prefetch thread
+  def fetch() =
+    r = f()
+    if
+      null.defined(r)
+    then
+      r = null.get(r)
+      s = request.once(r)
+      if
+        s.resolve()
+      then
+        log.info(
+          "Added request on queue: #{request.uri(r)}."
+        )
+        queue := [...queue(), s]
+        true
+      else
+        log.important(
+          "Failed to resolve request #{request.uri(r)}."
+        )
+        false
+      end
+    else
+      false
+    end
+  end
+
+  def fill() =
+    if list.length(queue()) < prefetch then ignore(fetch()) end
+  end
+
+  thread.run(every=retry_delay, fill)
+
+  # Source
+  def s() =
+    if
+      not list.is_empty(queue())
+    then
+      let [s, ...rest] = queue()
+      queue := rest
+      current := s
+      s
+    else
+      source.fail()
+    end
+  end
+
+  source.dynamic(id=id, track_sensitive=true, s).{
+    fetch = fetch,
+    queue = get_queue,
+    add = add,
+    set_queue = set_queue,
+    current = get_current
+  }
+end

--- a/tests/liq/extra/openai.liq
+++ b/tests/liq/extra/openai.liq
@@ -1,0 +1,150 @@
+let error.openai = error.register("openai")
+
+openai = ()
+
+# @flag hidden
+def parse_openai_error(ans, err) =
+  try
+    let json.parse (e : {error: {message: string, type: string}}) = ans
+
+    e = e.error
+
+    error.raise(
+      error.openai,
+      "#{e.type}: #{e.message}"
+    )
+  catch _ do
+    error.raise(err)
+  end
+end
+
+# Query ChatGPT API.
+# @param ~base_url Base URL for the API query
+# @param ~key OpenAI API key.
+# @param ~model Language model.
+# @param ~timeout Timeout for network operations in seconds.
+# @param messages Messages initially exchanged.
+# @category Internet
+# @flag extra
+def openai.chat(
+  ~key,
+  ~base_url="https://api.openai.com",
+  ~model="gpt-3.5-turbo",
+  ~timeout=null(30.),
+  (
+  messages:
+  [
+    {
+      role: string,
+      content: string,
+      name?: string,
+      tool_calls?: [
+        {id: string, type: string, function: {name: string, arguments: string}}
+      ],
+      tool_call_id?: string
+    }
+  ]
+  )
+) =
+  payload = {model = model, messages = messages}
+
+  ans =
+    http.post(
+      data=json.stringify(payload),
+      timeout=timeout,
+      headers=[
+        ("Content-Type", "application/json"),
+        (
+          "Authorization",
+          "Bearer #{(key : string)}"
+        )
+      ],
+      "#{base_url}/v1/chat/completions"
+    )
+
+  if
+    ans.status_code != 200
+  then
+    error.raise(
+      error.http,
+      "#{ans.status_code}: #{ans.status_message}"
+    )
+  end
+
+  try
+    let json.parse (ans :
+      {
+        choices: [
+          {
+            finish_reason: string,
+            index: int,
+            message: {content: string, role: string}
+          }
+        ],
+        created: int,
+        model: string,
+        object: string,
+        usage: {completion_tokens: int, prompt_tokens: int, total_tokens: int}
+      }
+    ) = ans
+    ans
+  catch err : [error.json] do
+    parse_openai_error(ans, err)
+  end
+end
+
+# Generate speech using openai. Returns the encoded audio data.
+# @param ~base_url Base URL for the API query
+# @param ~key OpenAI API key.
+# @param ~model Language model.
+# @param ~timeout Timeout for network operations in seconds.
+# @param ~voice The voice to use when generating the audio. Supported voices are `"alloy"`, `"echo"`, `"fable"`, `"onyx"`, `"nova"`, and `"shimmer"`
+# @param ~response_format The format to audio in. Supported formats are: `"mp3"`, `"opus"`, `"aac"`, and `"flac"`.
+# @param ~speed The speed of the generated audio. Select a value from `0.25` to `4.0`. `1.0` is the default.
+# @params ~on_data Function executed when receiving the audio data.
+# @category Internet
+# @flag extra
+def openai.speech(
+  ~key,
+  ~base_url="https://api.openai.com",
+  ~model="tts-1",
+  ~timeout=null(30.),
+  ~voice,
+  ~response_format="mp3",
+  ~speed=1.,
+  ~on_data,
+  (input:string)
+) =
+  payload =
+    {
+      model = model,
+      input = input,
+      voice = (voice : string),
+      response_format = response_format,
+      speed = speed
+    }
+
+  ans =
+    http.post.stream(
+      data=json.stringify(payload),
+      timeout=timeout,
+      headers=[
+        ("Content-Type", "application/json"),
+        (
+          "Authorization",
+          "Bearer #{(key : string)}"
+        )
+      ],
+      on_body_data=on_data,
+      "#{base_url}/v1/audio/speech"
+    )
+
+  if
+    ans.status_code != 200
+  then
+    error.raise(
+      error.http,
+      "#{ans.status_code}: #{ans.status_message}"
+    )
+  end
+end

--- a/tests/liq/extra/server.liq
+++ b/tests/liq/extra/server.liq
@@ -1,0 +1,177 @@
+# Register a command that outputs the RMS of the returned source.
+# @flag extra
+# @category Source / Visualization
+# @param ~id Force the value of the source ID.
+def server.rms(~id=null, s) =
+  let s = rms(id=id, s)
+
+  def rms(_) =
+    rms = s.rms()
+    "#{rms}"
+  end
+
+  s.register_command(
+    description="Return the current RMS of the source.",
+    usage="rms",
+    "rms",
+    rms
+  )
+
+  s
+end
+
+# Register a server/telnet command to update a source's metadata. Returns a new
+# source, which will receive the updated metadata. The command has the following
+# format: insert key1="val1",key2="val2",...
+# @flag extra
+# @category Source / Track processing
+# @param ~id Force the value of the source ID.
+def server.insert_metadata(s) =
+  def insert(s) =
+    let (meta, _) = string.annotate.parse("#{s}:")
+    if
+      meta != []
+    then
+      s.insert_metadata(meta)
+      "Done"
+    else
+      "Syntax error or no metadata given. Use key1=\"val1\",key2=\"val2\",.."
+    end
+  end
+
+  s.register_command(
+    description="Insert a metadata chunk.",
+    usage="insert key1=\"val1\",key2=\"val2\",..",
+    "insert",
+    insert
+  )
+
+  s
+end
+
+# Start an interface for the "telnet" server over http.
+# @category Internet
+# @flag extra
+# @param ~port Port of the server.
+# @param ~transport Http transport. Use `http.transport.ssl` or http.transport.secure_transport`, when available, to enable HTTPS output
+# @param ~uri URI of the server.
+def server.harbor(~transport=http.transport.unix, ~port=8000, ~uri="/telnet") =
+  def webpage(_, response) =
+    response.html(
+      "
+<html>
+  <head>
+    <meta charset='utf-8'/>
+    <title>Liquidsoap telnet server</title>
+    <style>
+      body {
+          font-family: sans-serif;
+      }
+      h1 {
+          text-align: center;
+      }
+      textarea {
+          display: block;
+          margin: 0 auto;
+          color: lightgreen;
+          background-color: black;
+          padding: 1ex;
+      }
+    </style>
+    <script>
+      window.onload = function () {
+        c = document.getElementById('console');
+
+        function send() {
+          var lines = c.value.substr(0, c.selectionStart).split('\\n');
+          var line = lines[lines.length-1];
+          var data = line;
+          console.log('send ' + line);
+          var xmlHttp = new XMLHttpRequest();
+          xmlHttp.open('POST', '#{
+        uri
+      }');
+          xmlHttp.onreadystatechange = function () {
+            if(xmlHttp.readyState === XMLHttpRequest.DONE) {
+              var status = xmlHttp.status;
+              if (status === 0 || (status >= 200 && status < 400)) {
+                c.value += xmlHttp.responseText + 'END\\n';
+                c.scrollTop = c.scrollHeight;
+              } else {
+                console.log('Failed to send values.')
+              }
+            }
+          }
+          xmlHttp.send(data);
+        }
+
+        c.addEventListener('keypress', function(e) {if (e.which == 13) {send()}})
+      }
+    </script>
+  </head>
+  <body>
+    <h1>Liquidsoap telnet server</h1>
+    <textarea id='console' cols='80' rows='25'></textarea>
+    <p style='text-align: center'>Type <code>help</code> if you are lost.</p>
+  </body>
+</html>
+"
+    )
+  end
+
+  harbor.http.register(
+    transport=transport,
+    port=port,
+    method="GET",
+    uri,
+    webpage
+  )
+
+  def setter(request, response) =
+    log.info(
+      "Executing command: #{request.data}"
+    )
+    answer = server.execute(request.body())
+    answer = string.concat(separator="\n", answer) ^ "\n"
+    response.data(answer)
+  end
+
+  harbor.http.register(
+    transport=transport,
+    port=port,
+    method="POST",
+    uri,
+    setter
+  )
+
+  log.important(
+    label="server.harbor",
+    "Website should be ready at <http://localhost:#{port}#{uri}>."
+  )
+end
+
+# Add a skip telnet command to a source when it does not have one by default.
+# @category Interaction
+# @flag extra
+# @param s The source to attach the command to.
+def add_skip_command(s) =
+  # A command to skip
+  def skip(_) =
+    s.skip()
+    "Done!"
+  end
+
+  s.on_wake_up(
+    synchronous=false,
+    {
+      # Register the command:
+      server.register(
+        namespace="#{source.id(s)}",
+        usage="skip",
+        description="Skip the current song.",
+        "skip",
+        skip
+      )
+    }
+  )
+end

--- a/tests/liq/extra/source.liq
+++ b/tests/liq/extra/source.liq
@@ -1,0 +1,476 @@
+# Apply a function to the first track of a source
+# @category Source / Track processing
+# @flag extra
+# @param ~id Force the value of the source ID.
+# @param fn The applied function.
+# @param s The input source.
+def map_first_track(~id=null("map_first_track"), fn, s) =
+  fallback(id=id, [fn((once(s) : source)), s])
+end
+
+# Same operator as rotate but merges tracks from each sources.
+# For instance, `rotate.merge([intro,main,outro])` creates a source
+# that plays a sequence `[intro,main,outro]` as single track and loops back.
+# @category Source / Track processing
+# @flag extra
+# @param ~id Force the value of the source ID.
+# @param sources Sequence of sources to be merged.
+def rotate.merge(~id=null("rotate.merge"), sources) =
+  sources =
+    (sources :
+      [
+        source.{
+          on_select?: (
+            {ending: source?, replay_metadata: bool, starting: source}
+          )->source,
+          on_leave?: ({source: source, track_sensitive: bool})->unit,
+          single?: bool,
+          track_sensitive?: getter(bool),
+          weight?: getter(int)
+        }
+      ]
+    )
+
+  ready = ref(true)
+  duration = frame.duration()
+
+  def to_first({starting, ..._}) =
+    ready := (not ready())
+    (sequence(merge=true, [blank(duration=duration), (starting : source)]) :
+      source
+    )
+  end
+
+  sources =
+    list.mapi(
+      fun (i, (s:source)) ->
+        if i == 0 then s.{on_select = to_first} else (s : source) end,
+      sources
+    )
+
+  s = rotate(sources)
+  let {track_marks = _, ...tracks} = source.tracks(s)
+  s = source(tracks).{replay_metadata = false}
+  switch(id=id, [(ready, s), ({not ready()}, s)])
+end
+
+# Rotate between overlapping sources. Next track starts according
+# to 'liq_start_next' offset metadata.
+# @category Source / Track processing
+# @flag extra
+# @param ~id Force the value of the source ID.
+# @param ~start_next Metadata field indicating when the next track should start, relative to current track's time.
+# @param ~weights Relative weight of the sources in the sum. The empty list stands for the homogeneous distribution.
+# @param sources Sources to toggle from
+def overlap_sources(
+  ~id=null("overlap_sources"),
+  ~normalize=false,
+  ~start_next="liq_start_next",
+  ~weights=[],
+  sources
+) =
+  position = ref(0)
+  length = list.length(sources)
+
+  def current_position() =
+    pos = position()
+    position := (pos + 1) mod length
+    pos
+  end
+
+  ready_list = list.map(fun (_) -> ref(false), sources)
+  grab_ready = fun (n) -> list.nth(default=ref(false), ready_list, n)
+
+  def set_ready(pos, b) =
+    is_ready = grab_ready(pos)
+    is_ready := b
+  end
+
+  # Start next track on_offset
+  def on_start_next(_, _) =
+    set_ready(current_position(), true)
+  end
+
+  def on_offset(s) =
+    let (s, offset) = metadata.getter.source.float(-1., start_next, s)
+    s.on_position(
+      synchronous=true,
+      allow_partial=true,
+      position=offset,
+      on_start_next
+    )
+  end
+
+  list.iter(on_offset, sources)
+
+  # Disable after each track
+  def disable(pos, s) =
+    def disable(_) =
+      set_ready(pos, false)
+    end
+
+    s.on_track(synchronous=true, disable)
+  end
+
+  list.iteri(disable, sources)
+
+  # Relay metadata from all sources
+  send_to_main_source = ref(fun (_) -> ())
+
+  def relay_metadata(m) =
+    fn = send_to_main_source()
+    fn(m)
+  end
+
+  list.iter(fun (s) -> s.on_metadata(synchronous=true, relay_metadata), sources)
+
+  def drop_metadata(s) =
+    let {metadata = _, ...tracks} = source.tracks(s)
+    source(tracks)
+  end
+
+  # Now drop all metadata
+  sources = list.map(drop_metadata, sources)
+
+  # Wrap sources into switches.
+  def make_switch(pos, source) =
+    is_ready = grab_ready(pos)
+    switch([(is_ready, source)])
+  end
+
+  sources = list.mapi(make_switch, sources)
+
+  # Initiate the whole thing.
+  set_ready(current_position(), true)
+
+  # Create main source
+  s = add(id=id, normalize=normalize, weights=weights, sources)
+
+  # Set send_to_main_source
+  send_to_main_source := fun (m) -> s.insert_metadata(m)
+  s
+end
+
+# Append speech-synthesized tracks reading the metadata.
+# @category Metadata
+# @flag extra
+# @param ~pattern Pattern to use
+# @param s The source to use
+def source.say_metadata =
+  def pattern(m) =
+    artist = m["artist"]
+    title = m["title"]
+    artist_predicate =
+      if
+        artist != ""
+      then
+        "It was #{artist} playing "
+      else
+        ""
+      end
+
+    say_metadata = "#{artist_predicate}#{title}"
+    say_metadata = r/:/g.replace(fun (_) -> '$(colon)', say_metadata)
+    say_metadata =
+      say_metadata == ""
+        ? "Sorry, I do not know what this song title was"
+        : say_metadata
+
+    "say:#{say_metadata}"
+  end
+
+  fun (~id=null("source.say_metadata"), ~pattern=pattern, s) ->
+    append(id=id, s, fun (m) -> once(single(pattern(m))))
+end
+
+# Regularly insert track boundaries in a stream (useful for testing tracks).
+# @category Source / Track processing
+# @flag extra
+# @param ~every Duration of a track (in seconds).
+# @param ~metadata Metadata for tracks.
+# @param s The stream.
+def chop(~every=getter(3.), ~metadata=getter([]), s) =
+  # Track time in the source's context:
+  time = ref(0.)
+
+  s = source.methods(s)
+
+  is_first = ref(true)
+
+  def f() =
+    time := time() + settings.frame.duration()
+    if
+      is_first() or getter.get(every) <= time()
+    then
+      is_first := false
+      time := 0.
+      s.insert_metadata(new_track=true, getter.get(metadata))
+    end
+  end
+
+  s.on_frame(synchronous=true, f)
+  s
+end
+
+# Regularly skip tracks from a source (useful for testing skipping).
+# @category Source / Track processing
+# @flag extra
+# @param ~every How often to skip tracks.
+# @param s The stream.
+# @flag extra
+def skipper(~every=getter(5.), s) =
+  start_time = ref(0.)
+
+  def f() =
+    if
+      getter.get(every) <= s.time() - start_time()
+    then
+      start_time := s.time()
+      s.skip()
+    end
+  end
+
+  s.on_frame(f)
+  s
+end
+
+# Special track insensitive fallback that always skips current song before
+# switching.
+# @category Source / Track processing
+# @flag extra
+# @param s The main source.
+# @param ~fallback The fallback source. Defaults to `blank` if `null`.
+def fallback.skip(s, ~fallback:f=null) =
+  f = f ?? (blank() : source)
+  avail = ref(true)
+
+  def check() =
+    old = avail()
+    avail := source.is_ready(s)
+    if not old and avail() then source.skip(f) end
+  end
+
+  s = fallback([s, f])
+
+  # TODO: could we have something more efficient that checking on every frame
+  s.on_frame(synchronous=true, check)
+  s
+end
+
+# Generate a CUE file for the source. This function will generate a new track in
+# the file for each metadata of the source. This function tries to map metadata to
+# the appropriate CUE file standard values. You can use the `map_metadata` argument
+# to add your own pre-processing. The following metadata are recognized on tracks:
+# `"title"`, `"artist"`, `"album"`, `"isrc"`, and `"cue_year"`.
+# @category Source / Track processing
+# @flag extra
+# @param filename Path where the CUE file should be written.
+# @param ~last_tracks Only report the number of last tracks.
+# @param ~title Title of the stream.
+# @param ~file File where the stream is stored.
+# @param ~file_type Format in which the stream is stored.
+# @param ~comment Comment about the stream.
+# @param ~year Year for the stream.
+# @param ~map_metadata Function to apply to metadata before writing the CUE file (useful for pre-processing metadata).
+# @param ~temp_dir Temporary directory for atomic write.
+# @param ~deduplicate_using To avoid duplicate entries, duplicate metadata are \
+#                           filtered. Set this to a list of labels to use for detecting \
+#                           duplicated metadata.
+# @param ~delete Delete the CUE files when starting if it exists.
+def source.cue(
+  ~title=null,
+  ~performer=null,
+  ~file:f=getter(null),
+  ~file_type=null,
+  ~comment=null,
+  ~year=null,
+  ~map_metadata=fun (m) -> (m : [(string * string)]),
+  ~last_tracks=null,
+  ~temp_dir=null,
+  ~deduplicate_using=["title", "artist", "album", "isrc", "cue_year"],
+  ~delete=true,
+  filename,
+  s
+) =
+  is_first = ref(true)
+  current_filename = ref("")
+
+  def write(~append, entries) =
+    filename = current_filename()
+    f = getter.get(f)
+    file_type = file_type ?? file.extension(leading_dot=false, f ?? "")
+
+    if
+      append
+    then
+      log(
+        label="source.cue",
+        level=4,
+        "Writing new entry to #{filename}"
+      )
+    else
+      log(
+        label="source.cue",
+        level=4,
+        "Writing full CUE file at #{filename}"
+      )
+      if delete and file.exists(filename) then file.remove(filename) end
+    end
+
+    write =
+      file.write.stream(append=append, atomic=true, temp_dir=temp_dir, filename)
+
+    # Append to the file.
+    def w(data) =
+      write(data ^ "\n")
+    end
+
+    # Write a tag.
+    def tag(~indent=0, ~quote=true, name, (value:string?)) =
+      quote = if quote then fun (v) -> string.quote(v) else fun (v) -> v end
+
+      if
+        null.defined(value)
+      then
+        s =
+          "#{string.spaces(indent)}#{name} #{quote(null.get(value))}"
+        w(s)
+      end
+    end
+
+    if
+      is_first() or not append
+    then
+      is_first := false
+
+      tag("TITLE", title)
+      tag("PERFORMER", performer)
+      tag(
+        "REM COMMENT",
+        comment
+      )
+      tag(
+        quote=false,
+        "REM DATE",
+        null.map(string.of_int, year)
+      )
+      if
+        null.defined(f)
+      then
+        w(
+          "FILE \"#{(null.get(f) : string)}\" #{string.uppercase(file_type)}"
+        )
+      end
+    end
+
+    list.iter(
+      fun (entry) ->
+        begin
+          let {position = p, time = t, metadata = m} = entry
+
+          tag(
+            indent=2,
+            quote=false,
+            "TRACK",
+            "#{string.of_int(digits=2, p)} AUDIO"
+          )
+          tag(indent=4, "TITLE", list.assoc.nullable("title", m))
+          tag(indent=4, "PERFORMER", list.assoc.nullable("artist", m))
+          tag(
+            indent=4,
+            "REM ALBUM",
+            list.assoc.nullable("album", m)
+          )
+          tag(
+            indent=4,
+            quote=false,
+            "REM DATE",
+            list.assoc.nullable("cue_year", m)
+          )
+          tag(indent=4, quote=false, "ISRC", list.assoc.nullable("isrc", m))
+
+          frames = int_of_float((t - floor(t)) * 75.)
+          t = int_of_float(t)
+          minutes = t / 60
+          seconds = t mod 60
+          m = string.of_int(digits=2, minutes)
+          s = string.of_int(digits=2, seconds)
+          f = string.of_int(digits=2, frames)
+          tag(
+            indent=4,
+            quote=false,
+            "INDEX 01",
+            "#{m}:#{s}:#{f}"
+          )
+        end,
+      entries
+    )
+
+    write("")
+  end
+
+  entries = ref([])
+  current_position = ref(1)
+  t0 = ref(source.time(s))
+
+  def handle_metadata(m) =
+    filename = getter.get(filename)
+    if
+      current_filename() != filename
+    then
+      log(
+        label="source.cue",
+        level=4,
+        "Opening new CUE sheet at #{filename}"
+      )
+      t0 := source.time(s)
+      current_position := 1
+      current_filename := filename
+      is_first := true
+    end
+
+    m = map_metadata(m)
+    entry =
+      {
+        position = current_position(),
+        time = source.time(s) - t0(),
+        metadata = m
+      }
+    ref.incr(current_position)
+
+    if
+      null.defined(last_tracks)
+    then
+      current_entries =
+        null.case(
+          last_tracks,
+          entries,
+          fun (last_tracks) ->
+            list.rev(list.prefix(last_tracks - 1, list.rev(entries())))
+        )
+      entries := [...current_entries, entry]
+      write(append=false, entries())
+    else
+      write(append=true, [entry])
+    end
+  end
+
+  s = metadata.deduplicate(using=deduplicate_using, s)
+  s.on_metadata(synchronous=true, handle_metadata)
+  s.on_frame(
+    before=false,
+    synchronous=true,
+    fun () ->
+      begin
+        # If filename has changed but no metadata handler was executed,
+        # insert one
+        if
+          current_filename() != getter.get(filename)
+        then
+          s.insert_metadata(new_track=true, s.last_metadata() ?? [])
+        end
+      end
+  )
+
+  s
+end

--- a/tests/liq/extra/spinitron.liq
+++ b/tests/liq/extra/spinitron.liq
@@ -1,0 +1,272 @@
+let spinitron = {submit = ()}
+
+# Submit a track to the spinitron track system
+# and return the raw response.
+# @category Interaction
+# @flag extra
+# @param ~api_key API key
+def spinitron.submit.raw(
+  ~host="https://spinitron.com/api",
+  ~api_key,
+  ~live=false,
+  ~start=null,
+  ~duration=null,
+  ~artist,
+  ~release=null,
+  ~label=null,
+  ~genre=null,
+  ~song,
+  ~composer=null,
+  ~isrc=null
+) =
+  params = [("song", song), ("artist", artist)]
+
+  def fold_optional_string_params(params, param) =
+    let (label, param) = param
+    if
+      null.defined(param)
+    then
+      [(label, null.get(param)), ...params]
+    else
+      params
+    end
+  end
+
+  params =
+    list.fold(
+      fold_optional_string_params,
+      params,
+      [
+        ("live", null.map(fun (b) -> b ? "1" : "0", (live : bool?))),
+        ("start", start),
+        ("duration", null.map(string, (duration : int?))),
+        ("release", release),
+        ("label", label),
+        ("genre", genre),
+        ("composer", composer),
+        ("isrc", isrc)
+      ]
+    )
+
+  def encode_param(param) =
+    let (label, param) = param
+    "#{label}=#{url.encode(param)}"
+  end
+
+  params = string.concat(separator="&", list.map(encode_param, params))
+
+  http.post(
+    data=params,
+    headers=[
+      ("Accept", "application/json"),
+      ("Content-Type", "application/x-www-form-urlencoded"),
+      (
+        "Authorization",
+        "Bearer #{(api_key : string)}"
+      )
+    ],
+    "#{host}/spins"
+  )
+end
+
+# Submit a track to the spinitron track system
+# and return the parsed response
+# @category Interaction
+# @flag extra
+# @param ~api_key API key
+def replaces spinitron.submit(%argsof(spinitron.submit.raw)) =
+  resp = spinitron.submit.raw(%argsof(spinitron.submit.raw))
+
+  if
+    resp.status_code == 201
+  then
+    let json.parse (resp :
+      {
+        id: int,
+        playlist_id: int,
+        "start" as spin_start: string,
+        "end" as spin_end: string?,
+        duration: int?,
+        timezone: string?,
+        image: string?,
+        classical: bool?,
+        artist: string,
+        "artist-custom" as artist_custom: string?,
+        composer: string?,
+        release: string?,
+        "release-custom" as release_custom: string?,
+        va: bool?,
+        label: string?,
+        "label-custom" as label_custom: string?,
+        released: int?,
+        medium: string?,
+        genre: string?,
+        song: string,
+        note: string?,
+        request: bool?,
+        local: bool?,
+        new: bool?,
+        work: string?,
+        conductor: string?,
+        performers: string?,
+        ensemble: string?,
+        "catalog-number" as catalog_number: string?,
+        isrc: string?,
+        upc: string?,
+        iswc: string?,
+        "_links" as links: {self: {href: string}?, playlist: {href: string}?}?
+      }
+    ) = resp
+
+    resp
+  elsif
+    resp.status_code == 422
+  then
+    let json.parse (errors : [{field: string, message: string}]) = resp
+
+    errors =
+      list.map(
+        fun (p) ->
+          begin
+            let {field, message} = p
+            "#{field}: #{message}"
+          end,
+        errors
+      )
+
+    errors =
+      string.concat(
+        separator=", ",
+        errors
+      )
+
+    error.raise(
+      error.raise(
+        error.http,
+        "Invalid fields: #{errors}"
+      )
+    )
+  else
+    let json.parse ({name, message, code, status, type} :
+      {name: string, message: string, code: int, status: int, type: string?}
+    ) = resp
+
+    type = type ?? "undefined"
+
+    error.raise(
+      error.raise(
+        error.http,
+        "#{name}: #{message} (code: #{code}, status: #{status}, type: #{type})"
+      )
+    )
+  end
+end
+
+# Submit a spin using the given metadata to the spinitron track system
+# and return the parsed response. `artist` and `song` (or `title`) must
+# be present either as metadata or as optional argument.
+# @category Interaction
+# @flag extra
+# @param m Metadata to submit. Overrides optional arguments when present.
+# @param ~mapper Metadata mapper that can be used to map metadata fields to spinitron's expected. \
+#                Returned metadata are added to the submitted metadata. By default, `title` is \
+#                mapped to `song` and `album` to `release` if neither of those passed otherwise.
+# @param ~api_key API key
+def spinitron.submit.metadata(
+  %argsof(spinitron.submit[!artist,!song]),
+  ~mapper=(
+    fun (m) ->
+      [
+        ...(m["song"] != "" or m["title"] == "" ? [] : [("song", m["title"])]),
+        ...(
+          m["release"] != "" or m["album"] == ""
+            ? []
+            : [("release", m["album"])]
+        )
+      ]
+  ),
+  ~artist=null,
+  ~song=null,
+  m
+) =
+  m = [...m, ...mapper(m)]
+
+  def conv_opt_arg(convert, label, default) =
+    list.assoc.mem(label, m) ? convert(m[label]) : default
+  end
+
+  opt_arg =
+    fun (label, default) -> conv_opt_arg(fun (x) -> null(x), label, default)
+
+  live = conv_opt_arg(bool_of_string, "live", live)
+  start = opt_arg("start", start)
+  duration = conv_opt_arg(int_of_string, "duration", duration)
+  artist = opt_arg("artist", artist)
+  release = opt_arg("release", release)
+  label = opt_arg("label", label)
+  genre = opt_arg("genre", genre)
+  song = opt_arg("song", song)
+  composer = opt_arg("composer", composer)
+  isrc = opt_arg("isrc", isrc)
+
+  if
+    artist == null or song == null
+  then
+    error.raise(
+      error.invalid,
+      "Both \"artist\" and \"song\" (or \"title\" metadata) must be provided!"
+    )
+  end
+
+  artist = null.get(artist)
+  song = null.get(song)
+
+  res = spinitron.submit(%argsof(spinitron.submit))
+
+  print(res)
+
+  res
+end
+
+# Specialized version of `s.on_metadata` that submits spins using
+# the source's metadata to the spinitron track system. `artist` and `song`
+# (or `title`) must be present either as metadata or as optional argument.
+# @category Interaction
+# @flag extra
+# @param m Metadata to submit. Overrides optional arguments when present.
+# @param ~api_key API key
+def spinitron.submit.on_metadata(%argsof(spinitron.submit.metadata), s) =
+  def on_metadata(m) =
+    if
+      m["title"] == "" and m["song"] == ""
+    then
+      log.severe(
+        label=source.id(s),
+        "Field \"song\" or \"title\" missing, skipping metadata spinitron \
+         submission."
+      )
+    elsif
+      m["artist"] == ""
+    then
+      log.severe(
+        label=source.id(s),
+        "Field \"artist\" missing, skipping metadata spinitron submission."
+      )
+    else
+      try
+        ignore(spinitron.submit.metadata(%argsof(spinitron.submit.metadata), m))
+        log.important(
+          label=source.id(s),
+          "Successfully submitted spin from metadata"
+        )
+      catch err do
+        log.severe(
+          label=source.id(s),
+          "Error while submitting spin from metadata: #{err}"
+        )
+      end
+    end
+  end
+
+  source.methods(s).on_metadata(synchronous=false, on_metadata)
+end

--- a/tests/liq/extra/telnet.liq
+++ b/tests/liq/extra/telnet.liq
@@ -1,0 +1,266 @@
+# @docof request.dynamic
+def replaces request.dynamic(%argsof(request.dynamic), fn) =
+  s = request.dynamic(%argsof(request.dynamic), fn)
+  s.on_wake_up(
+    synchronous=false,
+    memoize(
+      {
+        server.register(
+          namespace=source.id(s),
+          description="Flush the queue and skip the current track",
+          "flush_and_skip",
+          fun (_) ->
+            try
+              s.set_queue([])
+              s.skip()
+              "Done."
+            catch err do
+              "Error while flushing and skipping source: #{err}"
+            end
+        )
+      }
+    )
+  )
+
+  s
+end
+
+# @docof blank.strip
+def replaces blank.strip(%argsof(blank.strip), s) =
+  s = blank.strip(%argsof(blank.strip), s)
+  s.on_wake_up(
+    synchronous=false,
+    memoize(
+      {
+        server.register(
+          namespace=source.id(s),
+          description="Check if the source is stripping.",
+          "is_stripping",
+          fun (_) -> begin "#{s.is_blank()}" end
+        )
+      }
+    )
+  )
+
+  s
+end
+
+# @docof output.external
+def replaces output.external(%argsof(output.external), f, p, s) =
+  s = output.external(%argsof(output.external), f, p, s)
+  s.on_wake_up(
+    synchronous=false,
+    memoize(
+      {
+        server.register(
+          namespace=s.id(),
+          description="Re-open the output.",
+          "reopen",
+          fun (_) ->
+            begin
+              s.reopen()
+              "Done."
+            end
+        )
+      }
+    )
+  )
+
+  s
+end
+
+# @docof input.external.avi
+def replaces input.external.avi(%argsof(input.external.avi), s) =
+  s = input.external.avi(%argsof(input.external.avi), s)
+  s.on_wake_up(
+    synchronous=false,
+    memoize(
+      {
+        server.register(
+          namespace=source.id(s),
+          description="Show internal buffer length (in seconds).",
+          "buffer_length",
+          fun (_) ->
+            begin
+              buffered = s.buffered()
+              audio = list.assoc(default=0., "audio", buffered)
+              video = list.assoc(default=0., "video", buffered)
+              total = min(audio, video)
+              "audio buffer length: #{audio}\nvideo buffer length: #{
+                video
+              }\ntotal buffer length: #{total}"
+            end
+        )
+      }
+    )
+  )
+
+  s
+end
+
+# @docof input.harbor
+def replaces input.harbor(%argsof(input.harbor), s) =
+  s = input.harbor(%argsof(input.harbor), s)
+  s.on_wake_up(
+    synchronous=false,
+    memoize(
+      {
+        begin
+          server.register(
+            namespace=source.id(s),
+            description="Stop current source client, if connected.",
+            "stop",
+            fun (_) ->
+              begin
+                s.stop()
+                "Done"
+              end
+          )
+
+          server.register(
+            namespace=source.id(s),
+            description="Display current status.",
+            "status",
+            fun (_) -> begin s.status() end
+          )
+
+          server.register(
+            namespace=source.id(s),
+            description="Get the buffer's length, in seconds.",
+            "buffer_length",
+            fun (_) -> begin "#{s.buffer_length()}" end
+          )
+        end
+      }
+    )
+  )
+
+  s
+end
+
+%ifdef input.http
+# @docof input.http
+def replaces input.http(%argsof(input.http), s) =
+  s = input.http(%argsof(input.http), s)
+  s.on_wake_up(
+    synchronous=false,
+    memoize(
+      {
+        begin
+          server.register(
+            namespace=source.id(s),
+            description="Start the source, if needed.",
+            "start",
+            fun (_) ->
+              begin
+                s.start()
+                "Done!"
+              end
+          )
+
+          server.register(
+            namespace=source.id(s),
+            description="Stop the source if connected.",
+            "stop",
+            fun (_) ->
+              begin
+                s.stop()
+                "Done!"
+              end
+          )
+
+          server.register(
+            namespace=source.id(s),
+            description="Get or set the stream's HTTP URL. Setting a new URL \
+             will not affect an ongoing connection.",
+            usage="url [url]",
+            "url",
+            fun (url) ->
+              begin
+                if
+                  url == ""
+                then
+                  s.url()
+                else
+                  begin
+                    s.set_url({url})
+                    "Done!"
+                  end
+                end
+              end
+          )
+
+          server.register(
+            namespace=source.id(s),
+            description="Return the current status of the source, either \
+             \"stopped\" (the source isn't trying to relay the HTTP stream), \
+             \"polling\" (attempting to connect to the HTTP stream) or \
+             \"connected <url>\" (connected to <url>, buffering or playing back \
+             the stream).",
+            "status",
+            fun (_) -> begin s.status() end
+          )
+
+          server.register(
+            namespace=source.id(s),
+            description="Get the buffer's length, in seconds.",
+            "buffer_length",
+            fun (_) ->
+              "#{list.fold(fun (l, (_, l')) -> max(l, l'), 0., s.buffered())}"
+          )
+        end
+      }
+    )
+  )
+
+  s
+end
+%endif
+
+# @docof lufs
+def replaces lufs(%argsof(lufs), s) =
+  s = lufs(%argsof(lufs), s)
+  s.on_wake_up(
+    synchronous=false,
+    memoize(
+      {
+        server.register(
+          namespace=source.id(s),
+          description="Current value for the LUFS (short-term value computed \
+           over the duration specified by the `window` parameter).",
+          "lufs",
+          fun (_) ->
+            "#{s.lufs()} LUFS"
+        )
+
+        server.register(
+          namespace=source.id(s),
+          description="Average LUFS value over the current track.",
+          "lufs_integrated",
+          fun (_) ->
+            "#{s.lufs_integrated()} LUFS"
+        )
+
+        server.register(
+          namespace=source.id(s),
+          description="Momentary LUFS (over a 400ms window).",
+          "lufs_momentary",
+          fun (_) ->
+            "#{s.lufs_momentary()} LUFS"
+        )
+      }
+    )
+  )
+
+  s
+end
+
+server.register(
+  description="Shutdown the running liquidsoap instance",
+  "shutdown",
+  fun (_) ->
+    begin
+      shutdown()
+      "OK"
+    end
+)

--- a/tests/liq/extra/video.liq
+++ b/tests/liq/extra/video.liq
@@ -1,0 +1,59 @@
+# Extract cover from the source's metadata and add it as a static image.
+# @category Track / Video processing
+# @flag extra
+# @param ~id Force the value of the source ID.
+# @param ~fallible Whether we are allowed to fail (in case the file is non-existent or invalid).
+# @param ~width Scale to width
+# @param ~height Scale to height
+# @param ~x x position.
+# @param ~y y position.
+# @param ~default Default cover file when no cover is available
+# @param ~mime_types Recognized mime types and their corresponding file extensions.
+def video.add_cover(
+  ~fallible=false,
+  ~width=null,
+  ~height=null,
+  ~x=getter(0),
+  ~y=getter(0),
+  ~mime_types=[
+    ("image/gif", "gif"),
+    ("image/jpg", "jpeg"),
+    ("image/jpeg", "jpeg"),
+    ("image/png", "png"),
+    ("image/webp", "webp")
+  ],
+  ~default,
+  s
+) =
+  cover_file = file.cover.manager(mime_types=mime_types, default=default)
+  s.on_metadata(synchronous=true, cover_file.set)
+  video.add_request(
+    fallible=fallible,
+    x=x,
+    y=y,
+    width=width,
+    height=height,
+    request=cover_file,
+    s
+  )
+end
+
+let video.ffmpeg = ()
+
+%ifdef input.ffmpeg
+# ffmpeg's test source video (useful for testing and debugging).
+# @category Source / Video processing
+# @flag extra
+def video.ffmpeg.testsrc(~id="video.testsrc") =
+  video =
+    "testsrc=size=#{video.frame.width()}x#{video.frame.height()}:rate=#{
+      video.frame.rate()
+    }"
+  audio = "sine=frequency=440:beep_factor=2:sample_rate=#{audio.samplerate()}"
+  input.ffmpeg(
+    id=id,
+    format="lavfi",
+    "#{video} [out0]; #{audio} [out1]"
+  )
+end
+%endif

--- a/tests/liq/extra/visualization.liq
+++ b/tests/liq/extra/visualization.liq
@@ -1,0 +1,68 @@
+# VU meter: display the audio volume (RMS in dB) on the standard output.
+# @category Source / Visualization
+# @flag extra
+# @param ~rms_min Minimal volume (dB).
+# @param ~rms_max Maximal volume (dB).
+# @param ~scroll Update the display in the same line.
+# @param ~window Duration in seconds of volume computation.
+def vumeter(~rms_min=-25., ~rms_max=-5., ~window=0.5, ~scroll=false, s) =
+  screen_width = 80
+  bar_width = screen_width
+  let s = rms(duration=window, s)
+
+  def display() =
+    v = dB_of_lin(s.rms())
+    x = (v - rms_min) / (rms_max - rms_min)
+    x = if x < 0. then 0. else x end
+    x = if x > 1. then 1. else x end
+    n = int_of_float(x * float_of_int(bar_width))
+    bar = ref("")
+    if not scroll then bar := "\r" end
+    for _ = 0 to n - 1 do bar := bar() ^ "="  end
+    for _ = 0 to bar_width - n - 1 do bar := bar() ^ "."  end
+    bar :=
+      bar() ^
+        " " ^
+        string(v)
+    if scroll then bar := bar() ^ "\n" end
+    print(newline=false, bar())
+  end
+
+  thread.run(fast=true, every=window, display)
+  s
+end
+
+# VU meter: display the audio volume (RMS in dB). This adds a video track to the
+# source.
+# @category Source / Visualization
+# @flag extra
+# @param ~rms_min Minimal volume (dB).
+# @param ~rms_max Maximal volume (dB).
+# @param ~window Duration in seconds of volume computation.
+# @param ~color Color of the display (0xRRGGBB).
+# @param ~persistence Persistence of the display (s).
+def video.vumeter(
+  ~rms_min=-35.,
+  ~rms_max=0.,
+  ~window=0.1,
+  ~color=0xff0000,
+  ~persistence=0.,
+  s
+) =
+  s = source(s.{video = source.tracks(blank()).video})
+  s = rms(duration=window, s)
+  height = video.frame.height()
+  width = ref(0)
+
+  def update() =
+    v = dB_of_lin(s.rms())
+    x = (v - rms_min) / (rms_max - rms_min)
+    x = if x < 0. then 0. else x end
+    x = if x > 1. then 1. else x end
+    width := int_of_float(x * float_of_int(video.frame.width()))
+  end
+
+  thread.run(fast=true, every=window, update)
+  s = video.add_rectangle(width=width, height=height, color=color, s)
+  video.persistence(duration=persistence, s)
+end

--- a/tests/liq/fades.liq
+++ b/tests/liq/fades.liq
@@ -1,0 +1,941 @@
+fade = ()
+
+let settings.fade =
+  settings.make.void(
+    "Settings for the fade in/out operators"
+  )
+
+let settings.fade.in =
+  settings.make.void(
+    "Settings for fade.in operators"
+  )
+
+let settings.fade.in.duration =
+  settings.make(
+    description="Default fade.in duration",
+    3.
+  )
+
+let settings.fade.in.type =
+  settings.make(
+    description="Default fade.in type",
+    "lin"
+  )
+
+let settings.fade.in.curve =
+  settings.make(
+    description="Default fade.in curve",
+    10.
+  )
+
+let settings.fade.out =
+  settings.make.void(
+    "Settings for fade.out operators"
+  )
+
+let settings.fade.out.duration =
+  settings.make(
+    description="Default fade.out duration",
+    3.
+  )
+
+let settings.fade.out.type =
+  settings.make(
+    description="Default fade.out type",
+    "lin"
+  )
+
+let settings.fade.out.curve =
+  settings.make(
+    description="Default fade.out curve",
+    10.
+  )
+
+# Make a fade function based on a source's clock.
+# @category Source / Fade
+# @param ~curve Fade curve for `"log"` and `"exp"` shapes. If `null`, depends on the type of fade. \
+#               The higher the value, the shaper the curve.
+# @param ~type Fade shape. One of: `"sin"`, `"exp"`, `"log"`, `"lin"`
+# @param ~start Start value.
+# @param ~stop Stop value.
+# @param ~delay Initial delay before starting fade.
+# @param ~duration Duration in seconds.
+# @param ~on_done Function to execute when the fade is finished
+def mkfade(
+  ~curve=null,
+  ~type="lin",
+  ~start=0.,
+  ~stop=1.,
+  ~delay=0.,
+  ~duration=3.,
+  ~on_done={()},
+  s
+) =
+  def log(x) =
+    log(label="mkfade", x)
+  end
+
+  # Shape functions must map 0. -> 0. and 1. -> 1.
+  pi = acos(-1.)
+
+  def sin_shape(x) =
+    (1. + sin((x - 0.5) * pi)) / 2.
+  end
+
+  exp_curve = curve ?? 3.
+  m = exp(exp_curve - 1.) - exp(-1.)
+
+  def exp_shape(x) =
+    (exp((exp_curve * x) - 1.) - exp(-1.)) / m
+  end
+
+  ln_curve = curve ?? 10.
+  m = ln(1. + ln_curve)
+
+  def log_shape(x) =
+    ln(1. + ln_curve * x) / m
+  end
+
+  def lin_shape(x) =
+    x
+  end
+
+  shape =
+    if
+      type == "sin"
+    then
+      sin_shape
+    elsif
+      type == "exp"
+    then
+      exp_shape
+    elsif
+      type == "log"
+    then
+      log_shape
+    elsif
+      type == "lin"
+    then
+      lin_shape
+    else
+      log(
+        "Invalid type #{type}, using \"lin\""
+      )
+      lin_shape
+    end
+
+  start_time = ref(-1.)
+  increasing_fade = start <= stop
+
+  def fade() =
+    if start_time() < 0. then start_time := source.time(s) end
+
+    t = source.time(s) - start_time() - delay
+    if
+      0. < duration and t <= 0.
+    then
+      start
+    elsif
+      t >= duration
+    then
+      on_done()
+      stop
+    else
+      if
+        increasing_fade
+      then
+        start + shape(t / duration) * (stop - start)
+      else
+        stop + shape(1. - t / duration) * (start - stop)
+      end
+    end
+  end
+
+  fade
+end
+
+# Scale source during fading.
+# @category Source / Fade
+# @flag hidden
+def fade.scale(~id="fade.scale", x, s) =
+  amplify(id=id, override=null, x, s)
+end
+
+# Fade the end of tracks.
+# @category Source / Fade
+# @param ~id Force the value of the source ID.
+# @param ~duration Duration of the fading. This value can be set on a per-file basis using the metadata field passed as override. Defaults to `settings.fade.out.curve` if `null`.
+# @param ~delay Initial delay before starting fade. Defaults to `settings.fade.out.delay` if `null`.
+# @param ~curve Fade curve. Defaults to `settings.fade.out.curve` if `null`.
+# @param ~override_duration Metadata field which, if present and containing a float, overrides the 'duration' parameter for the current track.
+# @param ~override_type Metadata field which, if present and correct, overrides the 'type' parameter for the current track.
+# @param ~override_curve Metadata field which, if presents and correct, overrides the `curve` parameter for the current track. Use `"default"` \
+#                        to set to default value.
+# @param ~override_delay Metadata field which, if presents and correct, overrides the initial fade delay.
+# @param ~persist_overrides Keep duration and type overrides on track change.
+# @param ~track_sensitive Be track sensitive (if `false` we only fade ou once at the beginning of the track).
+# @param ~initial_metadata Initial metadata.
+# @param ~type Fader shape. One of: "lin"", "sin", "log" or "exp". Defaults to `settings.fade.out.type` if `null`.
+def fade.out(
+  ~id="fade.out",
+  ~duration=null,
+  ~delay=0.,
+  ~curve=null,
+  ~override_duration="liq_fade_out",
+  ~override_type="liq_fade_out_type",
+  ~override_curve="liq_fade_out_curve",
+  ~override_delay="liq_fade_out_delay",
+  ~persist_overrides=false,
+  ~track_sensitive=false,
+  ~initial_metadata=[],
+  ~type=null,
+  s
+) =
+  def log(~level=4, x) =
+    log(label=source.id(s), level=level, x)
+  end
+
+  fn = ref(fun () -> 1.)
+  original_type = type ?? settings.fade.out.type()
+  type = ref(original_type)
+  original_curve = (curve ?? settings.fade.out.curve() : float?)
+  curve = ref(original_curve)
+  original_duration = duration ?? settings.fade.out.duration()
+  duration = ref(original_duration)
+  original_delay = delay
+  delay = ref(original_delay)
+  start_time = ref(-1.)
+  started = ref(false)
+  last_metadata = ref(initial_metadata)
+
+  def start_fade(d, _) =
+    curve_log =
+      if null.defined(curve()) then string(null.get(curve())) else "default" end
+
+    start_time := source.time(s)
+    let (delay, duration) =
+      if
+        d < delay() + duration()
+      then
+        if
+          d < duration()
+        then
+          (0., d)
+        else
+          (max(0., d - duration()), duration())
+        end
+      else
+        (delay(), duration())
+      end
+
+    log(
+      "Fading out with type: #{type()}, curve: #{curve_log}, delay: #{delay}s, \
+       duration: #{duration}s and #{d}s remaining."
+    )
+
+    fn :=
+      mkfade(
+        start=1.,
+        stop=0.,
+        type=type(),
+        curve=curve(),
+        delay=delay,
+        duration=duration,
+        s
+      )
+    started := true
+  end
+
+  def apply() =
+    fn = fn()
+    fn()
+  end
+
+  def stop_fade(_) =
+    if
+      started()
+    then
+      fn := fun () -> 1.
+      started := false
+    end
+  end
+
+  def update_fade(m) =
+    if
+      m[override_duration] != ""
+    then
+      old_duration = duration()
+      duration := float_of_string(default=duration(), m[override_duration])
+
+      if
+        duration() != old_duration
+      then
+        log(
+          "New fade out duration: #{duration()}s."
+        )
+      end
+    end
+
+    if
+      m[override_delay] != ""
+    then
+      old_delay = delay()
+      delay := float_of_string(default=0., m[override_delay])
+
+      if
+        delay() != old_delay
+      then
+        log(
+          "New fade out delay: #{delay()}s."
+        )
+      end
+    end
+
+    if
+      m[override_curve] != ""
+    then
+      old_curve = curve()
+
+      if
+        m[override_curve] == "default"
+      then
+        curve := null
+      else
+        try
+          curve := float_of_string(m[override_curve])
+        catch _ do
+          curve := null
+        end
+      end
+
+      if
+        curve() != old_curve
+      then
+        log(
+          "New fade out curve: #{curve()}."
+        )
+      end
+    end
+
+    if
+      m[override_type] != ""
+    then
+      old_type = type()
+      type := m[override_type]
+
+      if
+        type() != old_type
+      then
+        log(
+          "New fade out type: #{type()}."
+        )
+      end
+    end
+  end
+
+  update_fade(last_metadata())
+
+  def reset_overrides(_) =
+    if
+      not persist_overrides
+    then
+      log(
+        "Setting fade out to default duration: #{original_duration}s, delay: #{
+          original_delay
+        }s, type: #{original_type}, curve: #{original_curve}"
+      )
+      duration := original_duration
+      delay := original_delay
+      type := original_type
+      curve := original_curve
+    end
+  end
+
+  s = source.methods(s)
+  s.on_track(synchronous=true, reset_overrides)
+  s.on_metadata(synchronous=true, update_fade)
+  if track_sensitive then s.on_track(synchronous=true, stop_fade) end
+
+  d = source.dynamic(memoize({s}))
+
+  if
+    track_sensitive
+  then
+    d.on_position(
+      synchronous=true,
+      remaining=true,
+      position=duration,
+      start_fade
+    )
+  else
+    d.on_frame(
+      synchronous=true,
+      before=false,
+      memoize({start_fade(source.remaining(s), [])})
+    )
+  end
+
+  # Make sure we generate a frame before starting the fade
+  # to ensure that we catch all the initial metadata.
+  d.on_frame(
+    synchronous=true,
+    before=true,
+    memoize({if s.is_ready() then s.generate_frame() end})
+  )
+
+  fade.scale(id=id, apply, d).{
+    fade_duration = {duration()},
+    fade_type = {type()}
+  }
+end
+
+# Fade when the metadata trigger is received and then skip.
+# @flag extra
+# @category Source / Fade
+# @flag extra
+# @param ~id Force the value of the source ID.
+# @param ~duration Duration of the fading. This value can be set on a per-file basis using the metadata field passed as override.
+# @param ~delay Initial delay before starting fade.
+# @param ~curve Fade curve. Default if `null`.
+# @param ~override_duration Metadata field which, if present and containing a float, overrides the 'duration' parameter for the current track.
+# @param ~override_type Metadata field which, if present and correct, overrides the 'type' parameter for the current track.
+# @param ~override_curve Metadata field which, if presents and correct, overrides the `curve` parameter for the current track. Use `"default"` \
+#                        to set to default value.
+# @param ~override_skip Metadata field which, when present and set to "true", will trigger the fade
+# @param ~persist_overrides Keep duration and type overrides on track change.
+# @param ~initial_metadata Initial metadata.
+# @param ~type Fader shape (lin|sin|log|exp): linear, sinusoidal, logarithmic or exponential.
+def fade.skip(
+  ~id="fade.skip",
+  ~duration=5.,
+  ~delay=0.,
+  ~curve=null,
+  ~override_duration="liq_fade_skip",
+  ~override_type="liq_fade_skip_type",
+  ~override_curve="liq_fade_skip_curve",
+  ~persist_overrides=false,
+  ~override_skip="liq_skip_meta",
+  ~initial_metadata=[],
+  ~type="lin",
+  s
+) =
+  def log(x) =
+    log(label=source.id(s), level=4, x)
+  end
+
+  fn = ref(fun () -> 1.)
+  original_type = type
+  type = ref(type)
+  original_curve = curve
+  curve = ref(curve)
+  original_duration = duration
+  duration = ref(duration)
+  original_delay = delay
+  delay = ref(original_delay)
+  last_metadata = ref(initial_metadata)
+
+  def apply() =
+    fn = fn()
+    fn()
+  end
+
+  def stop_fade(_) =
+    fn := fun () -> 1.
+  end
+
+  def skip() =
+    log(
+      "Fade finished executing. Calling skip now"
+    )
+    source.skip(s)
+  end
+
+  def update_fade(m) =
+    if
+      m[override_skip] == "true"
+    then
+      remaining = source.remaining(s)
+      duration = if remaining < duration() then remaining else duration() end
+      log(
+        "Skip fade executed for: #{duration}s"
+      )
+      fn :=
+        mkfade(
+          start=1.,
+          stop=0.,
+          type=type(),
+          curve=curve(),
+          duration=duration,
+          delay=delay(),
+          on_done=skip,
+          s
+        )
+    end
+
+    if
+      m[override_duration] != ""
+    then
+      old_duration = duration()
+      duration := float_of_string(default=duration(), m[override_duration])
+
+      if
+        duration() != old_duration
+      then
+        log(
+          "New fade skip duration: #{duration()}s."
+        )
+      end
+    end
+
+    if
+      m[override_curve] != ""
+    then
+      old_curve = curve()
+
+      if
+        m[override_curve] == "default"
+      then
+        curve := null
+      else
+        try
+          curve := float_of_string(m[override_curve])
+        catch _ do
+          curve := null
+        end
+      end
+
+      if
+        curve() != old_curve
+      then
+        log(
+          "New fade skip curve: #{curve()}."
+        )
+      end
+    end
+
+    if
+      m[override_type] != ""
+    then
+      old_type = type()
+      type := m[override_type]
+
+      if
+        type() != old_type
+      then
+        log(
+          "New fade skip type: #{type()}."
+        )
+      end
+    end
+  end
+
+  update_fade(last_metadata())
+
+  def reset_overrides(_) =
+    if
+      not persist_overrides
+    then
+      log(
+        "Setting fade skip to default duration: #{original_duration}s, delay: #{
+          original_delay
+        }s, type: #{original_type}, curve: #{original_curve}"
+      )
+      duration := original_duration
+      type := original_type
+      curve := original_curve
+    end
+  end
+
+  s = source.methods(s)
+  s.on_track(synchronous=true, reset_overrides)
+  s.on_metadata(synchronous=true, update_fade)
+  s.on_track(synchronous=true, stop_fade)
+
+  fade.scale(id=id, apply, s).{
+    fade_duration = {duration()},
+    fade_type = {type()}
+  }
+end
+
+# Fade the beginning of tracks.
+# @category Source / Fade
+# @param ~id Force the value of the source ID.
+# @param ~duration Duration of the fading. This value can be set on a per-file basis using the metadata field passed as override. Defaults to `settings.fade.in.duration` if `null`.
+# @param ~delay Initial delay before starting fade.
+# @param ~curve Fade curve. Defaults to `settings.fade.in.curve` if `null`.
+# @param ~override_duration Metadata field which, if present and containing a float, overrides the 'duration' parameter for the current track.
+# @param ~override_type Metadata field which, if present and correct, overrides the 'type' parameter for the current track.
+# @param ~override_curve Metadata field which, if presents and correct, overrides the `curve` parameter for the current track. Use `"default"` \
+#                        to set to default value.
+# @param ~override_delay Metadata field which, if presents and correct, overrides the initial fade delay.
+# @param ~persist_overrides Keep duration and type overrides on track change.
+# @param ~track_sensitive Be track sensitive (if `false` we only fade in once at the beginning of the track).
+# @param ~initial_metadata Initial metadata.
+# @param ~type Fader shape. One of: "lin"", "sin", "log" or "exp". Defaults to `settings.fade.in.type` if `null`.
+def fade.in(
+  ~id="fade.in",
+  ~duration=null,
+  ~delay=0.,
+  ~curve=null,
+  ~override_duration="liq_fade_in",
+  ~override_type="liq_fade_in_type",
+  ~override_curve="liq_fade_in_curve",
+  ~override_delay="liq_fade_in_delay",
+  ~persist_overrides=false,
+  ~track_sensitive=false,
+  ~initial_metadata=[],
+  ~type=null,
+  s
+) =
+  def log(~level=4, x) =
+    log(label=source.id(s), level=level, x)
+  end
+
+  fn = ref(fun () -> 0.)
+  original_duration = duration ?? settings.fade.in.duration()
+  duration = ref(original_duration)
+  original_delay = delay
+  delay = ref(original_delay)
+  original_type = type ?? settings.fade.in.type()
+  type = ref(original_type)
+  original_curve = curve ?? settings.fade.in.curve()
+  curve = ref(curve)
+  last_metadata = ref(initial_metadata)
+
+  def apply() =
+    fn = fn()
+    fn()
+  end
+
+  def start_fade(_) =
+    curve_log =
+      if null.defined(curve()) then string(null.get(curve())) else "default" end
+
+    duration =
+      if
+        source.remaining(s) < duration()
+      then
+        source.remaining(s)
+      else
+        duration()
+      end
+
+    log(
+      "Fading in with type: #{type()}, curve: #{curve_log}, delay: #{delay()}s \
+       and duration: #{duration}s."
+    )
+
+    # Note: delay here must match the add delay via blank to make the curve also match
+    fn :=
+      mkfade(
+        start=0.,
+        stop=1.,
+        type=type(),
+        curve=curve(),
+        delay=delay(),
+        duration=duration,
+        s
+      )
+  end
+
+  def update_fade(m) =
+    if
+      m[override_duration] != ""
+    then
+      old_duration = duration()
+      duration := float_of_string(default=duration(), m[override_duration])
+
+      if
+        duration() != old_duration
+      then
+        log(
+          "New fade in duration: #{duration()}s."
+        )
+      end
+    end
+
+    if
+      m[override_delay] != ""
+    then
+      old_delay = delay()
+      delay := float_of_string(default=0., m[override_delay])
+
+      if
+        delay() != old_delay
+      then
+        log(
+          "New fade in delay: #{delay()}s."
+        )
+      end
+    end
+
+    if
+      m[override_curve] != ""
+    then
+      old_curve = curve()
+
+      if
+        m[override_curve] == "default"
+      then
+        curve := null
+      else
+        try
+          curve := float_of_string(m[override_curve])
+        catch _ do
+          curve := null
+        end
+      end
+
+      if
+        curve() != old_curve
+      then
+        log(
+          "New fade in curve: #{curve()}."
+        )
+      end
+    end
+
+    if
+      m[override_type] != ""
+    then
+      old_type = type()
+      type := m[override_type]
+
+      if
+        type() != old_type
+      then
+        log(
+          "New fade in type: #{type()}."
+        )
+      end
+    end
+  end
+
+  update_fade(last_metadata())
+
+  def reset_overrides(_) =
+    if
+      not persist_overrides
+    then
+      log(
+        "Setting fade in to default duration: #{original_duration}s, delay: #{
+          original_delay
+        }s, type: #{original_type}, curve: #{original_curve}"
+      )
+      duration := original_duration
+      delay := original_delay
+      type := original_type
+      curve := original_curve
+    end
+  end
+
+  s = source.methods(s)
+  s.on_track(synchronous=true, reset_overrides)
+  s.on_metadata(synchronous=true, update_fade)
+
+  # Register start_fade on the inner source so it fires before the amplify
+  # operator processes the new track head.
+  if track_sensitive then s.on_track(synchronous=true, start_fade) end
+
+  # Initial duration for fade.in should be computed after fetching the initial
+  # frame from s to make sure any initial metadata is taken into account
+  prepare = ref(fun (_) -> ())
+  s =
+    source.dynamic(
+      memoize(
+        fun () ->
+          begin
+            prepare = prepare()
+            prepare(s)
+            if s.is_active() then s.generate_frame() end
+            delay = delay()
+            if
+              delay > 0.
+            then
+              effective_source = source.methods(source.effective(s))
+              if
+                s.is_active()
+              then
+                log(
+                  level=2,
+                  "Active source #{effective_source.id()} is faded in after an \
+                   initial delay of #{delay}s. This will result is initial data \
+                   loss since the source will be animated while the delay \
+                   expires."
+                )
+              end
+              sequence(merge=true, [blank(duration=delay), s])
+            else
+              s
+            end
+          end
+      )
+    )
+
+  s = fade.scale(id=id, apply, s)
+
+  if
+    not track_sensitive
+  then
+    s.on_frame(synchronous=true, before=false, memoize({start_fade([])}))
+  end
+  s.{fade_duration = {duration()}, fade_delay = {delay()}, fade_type = {type()}}
+end
+
+# Simple transition for crossfade
+# @category Source / Fade
+# @param ~log Logging utility
+# @param ~fade_in  Fade-in duration, if any.
+# @param ~fade_out Fade-out duration, if any.
+# @param ~initial_fade_in_metadata Initial fade-in metadata
+# @param ~initial_fade_out_metadata Initial fade-out metadata
+# @param ~ending_map Optional mapping for the ending track
+# @param ~starting_map Optional mapping for the starting track
+# @param a Ending track
+# @param b Starting track
+def cross.simple(
+  ~log=(fun (s) -> log(label="cross.simple", level=3, s)),
+  ~fade_in=3.,
+  ~fade_out=3.,
+  ~initial_fade_in_metadata=[],
+  ~initial_fade_out_metadata=[],
+  ~ending_map=fun (s) -> s,
+  ~starting_map=fun (s) -> s,
+  a,
+  b
+) =
+  fade_out_start_next =
+    if
+      list.assoc.mem("liq_fade_out_start_next", initial_fade_out_metadata)
+    then
+      float_of_string(initial_fade_out_metadata["liq_fade_out_start_next"])
+    else
+      0.
+    end
+
+  fade_in_delay =
+    if
+      list.assoc.mem("liq_fade_in_delay", initial_fade_in_metadata)
+    then
+      float_of_string(initial_fade_in_metadata["liq_fade_in_delay"])
+    else
+      fade_out_start_next
+    end
+
+  fade_in_delay =
+    if
+      source.duration(b) < source.duration(a)
+    then
+      delay = source.duration(a) - source.duration(b)
+      log(
+        "Adding #{delay} of fade_in_delay to match ending source"
+      )
+      fade_in_delay + delay
+    else
+      fade_in_delay
+    end
+
+  def fade.out(s) =
+    fade.out(
+      type="sin",
+      persist_overrides=true,
+      duration=fade_out,
+      initial_metadata=initial_fade_out_metadata,
+      s
+    )
+  end
+
+  def fade.in(s) =
+    fade.in(
+      type="sin",
+      persist_overrides=true,
+      duration=fade_in,
+      initial_metadata=[
+        ...list.assoc.remove("liq_fade_in_delay", initial_fade_in_metadata),
+        ("liq_fade_in_delay", "#{fade_in_delay}")
+      ],
+      s
+    )
+  end
+
+  add = fun (a, b) -> add(normalize=false, [starting_map(b), ending_map(a)])
+  add(fade.out(a), fade.in(b))
+end
+
+# @docof cross
+# @param ~deduplicate  Crossfade transitions can generate duplicate metadata. When `true`, the operator \
+#                      removes duplicate metadata from the returned source.
+def replaces cross(%argsof(cross), ~deduplicate=true, transition, s) =
+  if
+    not deduplicate
+  then
+    cross(%argsof(cross), transition, s)
+  else
+    s = cross(%argsof(cross[!id]), transition, s)
+    dedup = metadata.deduplicate(s)
+
+    dedup.{
+      buffered = s.buffered,
+      duration = s.duration,
+      cross_duration = s.cross_duration
+    }
+  end
+end
+
+# Crossfade between tracks, taking the respective volume levels into account in
+# the choice of the transition.
+# @category Source / Fade
+# @argsof cross[id,duration,override_duration,persist_override,width]
+# @param ~deduplicate  Crossfade transitions can generate duplicate metadata. When `true`, the operator \
+#                      removes duplicate metadata from the returned source.
+# @param s             The input source.
+def crossfade(
+  %argsof(cross[id,duration,override_duration,persist_override,width]),
+  ~fade_in=3.,
+  ~fade_out=3.,
+  ~deduplicate=true,
+  s
+) =
+  id = string.id.default(default="crossfade", id)
+
+  def log(~level=3, x) =
+    log(label=id, level=level, x)
+  end
+
+  def transition(a, b) =
+    list.iter(
+      fun (x) ->
+        log(
+          level=4,
+          "Before: #{x}"
+        ),
+      a.metadata
+    )
+
+    list.iter(
+      fun (x) ->
+        log(
+          level=4,
+          "After : #{x}"
+        ),
+      b.metadata
+    )
+
+    cross.simple(
+      log=log,
+      fade_in=fade_in,
+      fade_out=fade_out,
+      initial_fade_in_metadata=b.metadata,
+      initial_fade_out_metadata=a.metadata,
+      a.source,
+      b.source
+    )
+  end
+
+  cross(
+    %argsof(cross[id,duration,override_duration,persist_override,width]),
+    deduplicate=deduplicate,
+    transition,
+    s
+  )
+end

--- a/tests/liq/ffmpeg.liq
+++ b/tests/liq/ffmpeg.liq
@@ -1,0 +1,605 @@
+%ifdef track.ffmpeg.raw.encode.audio
+let ffmpeg.encode = ()
+let ffmpeg.raw.encode = ()
+
+# Encode a source's audio content
+# @category Source / Conversion
+def ffmpeg.encode.audio(~id=null("ffmpeg.encode.audio"), f, s) =
+  audio = track.ffmpeg.encode.audio(f, source.tracks(s).audio)
+  source(
+    id=id,
+    {
+      track_marks = track.track_marks(audio),
+      metadata = track.metadata(audio),
+      audio = audio
+    }
+  )
+end
+
+# Encode a source's audio content
+# @category Source / Conversion
+def ffmpeg.raw.encode.audio(~id=null("ffmpeg.raw.encode.audio"), f, s) =
+  audio = track.ffmpeg.raw.encode.audio(f, source.tracks(s).audio)
+  source(
+    id=id,
+    {
+      track_marks = track.track_marks(audio),
+      metadata = track.metadata(audio),
+      audio = audio
+    }
+  )
+end
+
+# Encode a source's video content
+# @category Source / Conversion
+def ffmpeg.encode.video(~id=null("ffmpeg.encode.video"), f, s) =
+  video = track.ffmpeg.encode.video(f, source.tracks(s).video)
+  source(
+    id=id,
+    {
+      track_marks = track.track_marks(video),
+      metadata = track.metadata(video),
+      video = video
+    }
+  )
+end
+
+# Encode a source's video content
+# @category Source / Conversion
+def ffmpeg.raw.encode.video(~id=null("ffmpeg.raw.encode.video"), f, s) =
+  video = track.ffmpeg.raw.encode.video(f, source.tracks(s).video)
+  source(
+    id=id,
+    {
+      track_marks = track.track_marks(video),
+      metadata = track.metadata(video),
+      video = video
+    }
+  )
+end
+
+# Encode a source's audio and video content
+# @category Source / Conversion
+def ffmpeg.encode.audio_video(~id=null("ffmpeg.encode.audio_video"), f, s) =
+  let {audio, video} = source.tracks(s)
+  audio = track.ffmpeg.encode.audio(f, audio)
+  video = track.ffmpeg.encode.video(f, video)
+  source(
+    id=id,
+    {
+      track_marks = track.track_marks(audio),
+      metadata = track.metadata(audio),
+      audio = audio,
+      video = video
+    }
+  )
+end
+
+# Encode a source's audio and video content
+# @category Source / Conversion
+def ffmpeg.raw.encode.audio_video(
+  ~id=null("ffmpeg.raw.encode.audio_video"),
+  f,
+  s
+) =
+  let {audio, video} = source.tracks(s)
+  audio = track.ffmpeg.raw.encode.audio(f, audio)
+  video = track.ffmpeg.raw.encode.video(f, video)
+  source(
+    id=id,
+    {
+      track_marks = track.track_marks(audio),
+      metadata = track.metadata(audio),
+      audio = audio,
+      video = video
+    }
+  )
+end
+%endif
+
+%ifdef track.ffmpeg.decode.audio
+let ffmpeg.decode = ()
+let ffmpeg.raw.decode = ()
+
+# Decode a source's audio content
+# @category Source / Conversion
+def ffmpeg.decode.audio(~id=null("ffmpeg.decode.audio"), s) =
+  audio = track.ffmpeg.decode.audio(source.tracks(s).audio)
+  source(
+    id=id,
+    {
+      track_marks = track.track_marks(audio),
+      metadata = track.metadata(audio),
+      audio = audio
+    }
+  )
+end
+
+# Decode a source's audio content
+# @category Source / Conversion
+def ffmpeg.raw.decode.audio(~id=null("ffmpeg.raw.decode.audio"), s) =
+  audio = track.ffmpeg.raw.decode.audio(source.tracks(s).audio)
+  source(
+    id=id,
+    {
+      track_marks = track.track_marks(audio),
+      metadata = track.metadata(audio),
+      audio = audio
+    }
+  )
+end
+
+# Decode a source's video content
+# @category Source / Conversion
+def ffmpeg.decode.video(~id=null("ffmpeg.decode.video"), s) =
+  video = track.ffmpeg.decode.video(source.tracks(s).video)
+  source(
+    id=id,
+    {
+      track_marks = track.track_marks(video),
+      metadata = track.metadata(video),
+      video = video
+    }
+  )
+end
+
+# Decode a source's video content
+# @category Source / Conversion
+def ffmpeg.raw.decode.video(~id=null("ffmpeg.raw.decode.video"), s) =
+  video = track.ffmpeg.raw.decode.video(source.tracks(s).video)
+  source(
+    id=id,
+    {
+      track_marks = track.track_marks(video),
+      metadata = track.metadata(video),
+      video = video
+    }
+  )
+end
+
+# Decode a source's audio and video content
+# @category Source / Conversion
+def ffmpeg.decode.audio_video(~id=null("ffmpeg.decode.audio_video"), s) =
+  let {audio, video} = source.tracks(s)
+  audio = track.ffmpeg.decode.audio(audio)
+  video = track.ffmpeg.decode.video(video)
+  source(
+    id=id,
+    {
+      track_marks = track.track_marks(audio),
+      metadata = track.metadata(audio),
+      audio = audio,
+      video = video
+    }
+  )
+end
+
+# Decode a source's audio and video content
+# @category Source / Conversion
+def ffmpeg.raw.decode.audio_video(
+  ~id=null("ffmpeg.raw.decode.audio_video"),
+  s
+) =
+  let {audio, video} = source.tracks(s)
+  audio = track.ffmpeg.raw.decode.audio(audio)
+  video = track.ffmpeg.raw.decode.video(video)
+  source(
+    id=id,
+    {
+      track_marks = track.track_marks(audio),
+      metadata = track.metadata(audio),
+      audio = audio,
+      video = video
+    }
+  )
+end
+%endif
+
+%ifdef input.ffmpeg
+# Stream from a video4linux2 input device, such as a webcam.
+# @category Source / Input / Active
+# @param ~id Force the value of the source ID.
+# @param ~max_buffer Maximum data buffer in seconds
+# @param ~device V4L2 device to use.
+def input.v4l2(~id=null, ~max_buffer=0.5, ~device="/dev/video0") =
+  (input.ffmpeg(id=id, format="v4l2", max_buffer=max_buffer, device) :
+    source(video=canvas)
+  )
+end
+
+# A test video source, which generates various patterns.
+# @category Source / Video processing
+# @param ~pattern Pattern drawn in the video: `"testsrc"`, `"testsrc2"`, `"smptebars"`, `"pal75bars"`, `"pal100bars"`, `"smptehdbars"`, `"yuvtestsrc"` or `"rgbtestsrc"` and more. Support any of the patterns supported by `ffmpeg`.
+# @param ~max_buffer Maximum data buffer in seconds
+# @param ~duration Duration of the source.
+def video.testsrc.ffmpeg(
+  ~id=null,
+  ~pattern="testsrc",
+  ~max_buffer=0.5,
+  ~duration=null
+) =
+  size = "size=#{settings.frame.video.width()}x#{settings.frame.video.height()}"
+  rate = "rate=#{settings.frame.video.framerate()}"
+  duration = if null.defined(duration) then ":duration=#{duration}" else "" end
+  src = "#{pattern}=#{size}:#{rate}#{duration}"
+  (input.ffmpeg(id=id, max_buffer=max_buffer, format="lavfi", src) :
+    source(video=canvas)
+  )
+end
+
+# Read an RTMP stream.
+# @category Source / Input / Active
+# @param ~max_buffer Maximum data buffer in seconds
+# @param ~listen Act as a RTMP server and wait for incoming connection
+# @param url URL to read RTMP from, in the form `rtmp://IP:PORT/ENDPOINT`
+def input.rtmp(~id=null, ~max_buffer=5., ~listen=true, url) =
+  input.ffmpeg(
+    id=id,
+    max_buffer=max_buffer,
+    format="live_flv",
+    self_sync=true,
+    int_args=[("listen", listen ? 1 : 0)],
+    url
+  )
+end
+%endif
+
+%ifdef ffmpeg.filter.drawtext
+let video.add_text.ffmpeg = ()
+let video.add_text.ffmpeg.raw = ()
+
+# Display a text. Use this operator inside ffmpeg filters with a ffmpeg video input
+# Returns a ffmpeg video output with `on_change` and `on_metadata` methods to be used
+# to update the output text.
+# @category Source / Video processing
+# @param ~color Text color (in 0xRRGGBB format).
+# @param ~cycle Cycle text when it reaches left boundary.
+# @param ~font Path to ttf font file.
+# @param ~metadata Change text on a particular metadata (empty string means disabled).
+# @param ~size Font size.
+# @param ~speed Horizontal speed in pixels per second (0 means no scrolling and update \
+#               according to x and y in case they are variable).
+# @param ~graph a ffmpeg filter graph to attach this filter to.
+# @param ~x x offset.
+# @param ~y y offset.
+# @params Text to display.
+# @method on_change Method to call when parameters have changed to update the filter's rendered out, including when text changes.
+# @method on_metadata Method to call on new metadata.
+def video.add_text.ffmpeg.raw.filter(
+  ~color=0xffffff,
+  ~cycle=true,
+  ~font=null,
+  ~metadata=null,
+  ~size=18,
+  ~speed=70,
+  ~x=getter(10),
+  ~y=getter(10),
+  ~graph,
+  d=getter(""),
+  s
+) =
+  color = "0x" ^ string.hex_of_int(pad=6, color)
+  x =
+    if
+      speed != 0
+    then
+      last_time = ref(time())
+      changed = getter.changes(x)
+      effective_x = ref(getter.get(x))
+      getter(
+        {
+          begin
+            cur_time = time()
+            traveled_to = int(float(speed) * (cur_time - last_time()))
+            last_time := cur_time
+            if
+              changed()
+            then
+              effective_x := getter.get(x)
+            else
+              effective_x := effective_x() - traveled_to
+            end
+
+            if
+              effective_x() < 0
+            then
+              effective_x := settings.frame.video.width() - effective_x()
+            end
+
+            effective_x()
+          end
+        }
+      )
+    else
+      x
+    end
+
+  filter =
+    ffmpeg.filter.drawtext.create(
+      fontfile=font,
+      fontsize="#{size}",
+      x="#{getter.get(x)}",
+      y="#{getter.get(y)}",
+      fontcolor=color,
+      text=getter.get(d),
+      graph
+    )
+
+  def escape =
+    def special_char(~encoding:_, s) =
+      string.contains(substring=s, "(',%,\\,:,{,})")
+    end
+
+    def escape_char(~encoding:_, s) =
+      "\\#{s}"
+    end
+
+    fun (s) ->
+      string.escape(special_char=special_char, escape_char=escape_char, s)
+  end
+
+  def escaped_text() =
+    escape(getter.get(d))
+  end
+
+  filters =
+    [
+      {
+        args =
+          getter(
+            {"x=#{getter.get(x)}:y=#{getter.get(y)}:text=#{escaped_text()}"}
+          ),
+        filter = filter
+      }
+    ]
+
+  filters =
+    if
+      cycle
+    then
+      x = getter({"min(#{getter.get(x)}-w,#{getter.get(x)}-text_w)"})
+      [
+        ...filters,
+        {
+          args =
+            getter(
+              {"x=#{getter.get(x)}:y=#{getter.get(y)}:text=#{escaped_text()}"}
+            ),
+          filter =
+            ffmpeg.filter.drawtext.create(
+              fontfile=font,
+              fontsize="#{size}",
+              x="#{getter.get(x)}",
+              y="#{getter.get(y)}",
+              fontcolor=color,
+              text=getter.get(d),
+              graph
+            )
+        }
+      ]
+    else
+      filters
+    end
+
+  changed =
+    getter.changes(getter({(getter.get(x), getter.get(y), getter.get(d))}))
+
+  def on_change() =
+    ignore(getter.get(x))
+    ignore(getter.get(y))
+    ignore(getter.get(d))
+    if
+      changed()
+    then
+      list.iter(
+        (
+          fun (el) ->
+            ignore(el.filter.process_command("reinit", getter.get(el.args)))
+        ),
+        filters
+      )
+    end
+  end
+
+  def on_metadata(m) =
+    if
+      null.defined(metadata)
+    then
+      meta = (null.get(metadata) : string)
+      d = escape(m[meta])
+      if
+        d != ""
+      then
+        log(
+          level=3,
+          label="ffmpeg.filter.drawtext",
+          "Setting new text #{d} from metadata #{meta}"
+        )
+
+        list.iter(
+          (
+            fun (el) -> ignore(el.filter.process_command("reinit", "text=#{d}"))
+          ),
+          filters
+        )
+      end
+    end
+  end
+
+  v =
+    list.fold(
+      (
+        fun (cur, el) ->
+          begin
+            el.filter.set_input(cur)
+            el.filter.output
+          end
+      ),
+      s,
+      filters
+    )
+
+  v.{on_change = on_change, on_metadata = on_metadata}
+end
+
+# Display a text. Use this operator inside ffmpeg filters with a input source
+# @category Source / Video processing
+# @param ~color Text color (in 0xRRGGBB format).
+# @param ~cycle Cycle text when it reaches left boundary.
+# @param ~font Path to ttf font file.
+# @param ~metadata Change text on a particular metadata (empty string means disabled).
+# @param ~size Font size.
+# @param ~speed Horizontal speed in pixels per second (0 means no scrolling and update \
+#               according to x and y in case they are variable).
+# @param ~graph a ffmpeg filter graph to attach this filter to.
+# @param ~x x offset.
+# @param ~y y offset.
+# @params Text to display.
+def replaces video.add_text.ffmpeg.raw(
+  ~color=0xffffff,
+  ~cycle=true,
+  ~font=null,
+  ~metadata=null,
+  ~size=18,
+  ~speed=70,
+  ~x=getter(10),
+  ~y=getter(10),
+  ~graph,
+  d=getter(""),
+  s
+) =
+  on_frame = ref(fun () -> ())
+  on_metadata = ref(fun (_) -> ())
+  s.on_metadata(
+    synchronous=true,
+    fun (m) ->
+      begin
+        fn = on_metadata()
+        fn(m)
+      end
+  )
+
+  s.on_frame(
+    synchronous=true,
+    fun () ->
+      begin
+        fn = on_frame()
+        fn()
+      end
+  )
+
+  s = ffmpeg.filter.video.input(graph, source.tracks(s).video)
+  v =
+    video.add_text.ffmpeg.raw.filter(
+      color=color,
+      cycle=cycle,
+      font=font,
+      metadata=metadata,
+      size=size,
+      speed=speed,
+      x=x,
+      y=y,
+      graph=graph,
+      d,
+      s
+    )
+
+  on_frame := v.on_change
+  on_metadata := v.on_metadata
+  ffmpeg.filter.null(graph, v)
+end
+
+def video.add_text.ffmpeg.internal(
+  ~id=null,
+  ~color=0xffffff,
+  ~cycle=true,
+  ~font=null,
+  ~duration=null,
+  ~metadata=null,
+  ~size=18,
+  ~speed=70,
+  ~x=getter(10),
+  ~y=getter(10),
+  d,
+  s
+) =
+  id = string.id.default(default="video.add_text.ffmpeg", id)
+  s = ffmpeg.raw.encode.audio_video(%ffmpeg(%audio.raw, %video.raw), s)
+
+  def mkfilter(graph) =
+    v =
+      video.add_text.ffmpeg.raw(
+        color=color,
+        cycle=cycle,
+        font=font,
+        metadata=metadata,
+        size=size,
+        speed=speed,
+        x=x,
+        y=y,
+        graph=graph,
+        d,
+        s
+      )
+
+    v = ffmpeg.filter.video.output(graph, v)
+
+    a = ffmpeg.filter.audio.input(graph, source.tracks(s).audio)
+    a = ffmpeg.filter.acopy(graph, a)
+    a = ffmpeg.filter.audio.output(graph, a)
+
+    source(
+      id=id,
+      {
+        audio = a,
+        video = v,
+        metadata = track.metadata(a),
+        track_marks = track.track_marks(a)
+      }
+    )
+  end
+
+  s = ffmpeg.filter.create(mkfilter)
+  s = ffmpeg.raw.decode.audio_video(s)
+  null.defined(duration) ? max_duration(null.get(duration), s) : s
+end
+
+# Display a text.
+# @category Source / Video processing
+# @param ~id Force the value of the source ID.
+# @param ~color Text color (in 0xRRGGBB format).
+# @param ~cycle Cycle text when it reaches left boundary.
+# @param ~font Path to ttf font file.
+# @param ~metadata Change text on a particular metadata (empty string means disabled).
+# @param ~size Font size.
+# @param ~speed Horizontal speed in pixels per second (0 means no scrolling and update \
+#               according to x and y in case they are variable).
+# @param ~x x offset.
+# @param ~y y offset.
+# @params Text to display.
+def replaces video.add_text.ffmpeg(
+  %argsof(video.add_text.ffmpeg.internal),
+  d,
+  s
+) =
+  video.add_text.ffmpeg.internal(%argsof(video.add_text.ffmpeg.internal), d, s)
+end
+%endif
+
+# video.add_text.available := [("ffmpeg", video.add_text.ffmpeg.internal), ...video.add_text.available()]
+
+# if settings.video.add_text() != "sdl" then
+#   settings.video.add_text.set("ffmpeg")
+# end
+%ifdef ffmpeg.filter.video.output
+let ffmpeg.filter.audio_video = ()
+
+# Return a source with audio and video from a filter's output.
+# @category Source / Output
+# @param id Force the value of the source ID.
+def ffmpeg.filter.audio_video.output(~id=null, graph, audio, video) =
+  audio = ffmpeg.filter.audio.output(graph, audio.tracks().audio)
+  video = ffmpeg.filter.video.output(graph, video.tracks().video)
+  source(id=id, {audio = audio, video = video})
+end
+%endif

--- a/tests/liq/file.liq
+++ b/tests/liq/file.liq
@@ -1,0 +1,387 @@
+# @docof file.temp
+# @param ~cleanup Delete the file on shutdown
+def file.temp(~cleanup=false, %argsof(file.temp), prefix, suffix) =
+  f = file.temp(%argsof(file.temp), prefix, suffix)
+  if cleanup then on_cleanup({file.remove(f)}) end
+  f
+end
+
+# @docof file.temp_dir
+# @param ~cleanup Delete the file on shutdown
+def file.temp_dir(~cleanup=false, prefix, suffix="") =
+  dir = file.temp_dir(prefix, suffix)
+  if cleanup then on_cleanup({file.rmdir(dir)}) end
+  dir
+end
+
+# Read the content of a file. Returns a function of type `()->string`. File is
+# done reading when function returns the empty string `""`.
+# @category File
+# @method close Close the underlying file descriptor without waiting for the whole file to be read.
+def file.read(fname) =
+  fd = file.open(write=false, fname)
+  is_done = ref(false)
+
+  def close() =
+    if
+      not is_done()
+    then
+      is_done := true
+      fd.close()
+    end
+  end
+
+  def read() =
+    if
+      is_done()
+    then
+      ""
+    else
+      s = fd.read()
+      if s == "" then close() end
+      s
+    end
+  end
+
+  read.{close = close}
+end
+
+let file.write = ()
+
+# Stream data to a file. Returns a callback to write to the file. Execute
+# with `null` or `""` to signify the end of the writing operation.
+# @category File
+# @param ~append Append data if file exists.
+# @param ~perms Default file rights if created. Default: `0o644`.
+# @param ~atomic Make the write atomic by writing to a temporary file and moving \
+#                the file to destination once writing has succeeded.
+# @param ~temp_dir Temporary directory for atomic write.
+# @param path Path to write to
+def file.write.stream(
+  ~perms=0o644,
+  ~append=false,
+  ~atomic=false,
+  ~temp_dir=null,
+  p
+) =
+  let (fd, exec) =
+    if
+      atomic
+    then
+      let (temp_dir, ensure) =
+        if
+          null.defined(temp_dir)
+        then
+          (null.get(temp_dir), {()})
+        else
+          temp_dir = file.temp_dir("temp", "dir")
+          (temp_dir, {file.rmdir(temp_dir)})
+        end
+      tmp = path.concat(temp_dir, "atomic.write")
+      if append and file.exists(p) then file.copy(p, tmp) end
+      def exec() =
+        try
+          file.move(atomic=true, tmp, p)
+        catch _ : [error.file.cross_device] do
+          log(
+            label="file.write",
+            "Atomic rename failed! Directory for temporary files appears to be \
+             on a different file system. Please set it to the same one using \
+             `temp_dir` argument to guarantee atomic file operations!"
+          )
+          file.copy(force=true, tmp, p)
+        finally
+          ensure()
+        end
+      end
+      fd = file.open(write=true, append=append, perms=perms, tmp)
+      (fd, exec)
+    else
+      (file.open(write=true, append=append, perms=perms, p), {()})
+    end
+
+  def write(s) =
+    s = s ?? ""
+    if
+      s == ""
+    then
+      if
+        not fd.closed()
+      then
+        fd.close()
+        exec()
+      end
+    else
+      fd.write(s)
+    end
+  end
+
+  write
+end
+
+# Write data to a file.
+# @category File
+# @param ~data Data to write. If passing a callback `() -> string?`, the callback \
+#              must return `null` or `""` when it has finished sending all its data.
+# @param ~append Append data if file exists.
+# @param ~perms Default file rights if created. Default: `0o644`.
+# @param ~atomic Make the write atomic by writing to a temporary file and moving \
+#                the file to destination once writing has succeeded.
+# @param ~temp_dir Temporary directory for atomic write.
+# @param path Path to write to.
+def replaces file.write(
+  ~data,
+  ~perms=0o644,
+  ~append=false,
+  ~atomic=false,
+  ~temp_dir=null,
+  path
+) =
+  cb =
+    file.write.stream(
+      append=append,
+      perms=perms,
+      atomic=atomic,
+      temp_dir=temp_dir,
+      path
+    )
+
+  try
+    s = ref(getter.get(data) ?? "")
+    cb(s())
+    if
+      getter.is_constant(data)
+    then
+      cb("")
+    else
+      while s() != "" do
+        s := getter.get(data) ?? ""
+        cb(s())
+
+      end
+    end
+  catch err do
+    cb("")
+    error.raise(err)
+  end
+end
+
+# Ensure that a file exists, creating it empty if it does not.
+# @category File
+# @param path Path of the file.
+def file.touch(~perms=0o644, path) =
+  file.write(data="", perms=perms, append=true, path)
+end
+
+# Read the whole contents of a file.
+# @category File
+def file.contents(fname) =
+  fn = file.read(fname)
+
+  cur = ref("")
+  next = ref(fn())
+  while next() != "" do
+    cur := "#{cur()}#{next()}"
+    next := fn()
+
+  end
+
+  cur()
+end
+
+# Get the list of lines of a file.
+# @category File
+def file.lines(fname) =
+  r/\n/.split(file.contents(fname))
+end
+
+# Iterate over the lines of a file.
+# @category File
+def file.lines.iterator(fname) =
+  list.iterator(file.lines(fname))
+end
+
+# Iterate over the contents of a file.
+# @category File
+def file.iterator(fname) =
+  f = file.read(fname)
+  fun () ->
+    begin
+      s = f()
+      (s == "") ? null : s
+    end
+end
+
+# Get a file's mime type by calling the `file` command line binary.
+# @category File
+def file.mime.cli(fname) =
+  mime =
+    list.hd(
+      default="",
+      process.read.lines(
+        process.quote.command("file", args=["-b", "--mime-type", fname])
+      )
+    )
+
+  mime == "" ? null : mime
+end
+
+# Get a file's mime type. Uses libmagic if enabled, otherwise try
+# to get the value using the file binary. Returns `null` if no value
+# can be found.
+# @category File
+# @param file The file to test
+def replaces file.mime(fname) =
+  fn = file.mime.cli
+%ifdef file.mime.libmagic
+  ignore(fn)
+  fn = file.mime.libmagic
+%endif
+
+  fn(fname)
+end
+
+# Getter to the contents of a file.
+# @category File
+# @param fname Name of the file from which the contents should be taken.
+def file.getter(fname) =
+  contents = ref("")
+
+  def update() =
+    contents := file.contents(fname)
+  end
+
+  update()
+  ignore(file.watch(fname, update))
+  ref.getter(contents)
+end
+
+# Float getter from a file.
+# @category File
+# @param fname Name of the file from which the contents should be taken.
+# @param ~default Default value when the file contains invalid data.
+def file.getter.float(~default=0., fname) =
+  x = file.getter(fname)
+
+  def f(x) =
+    float_of_string(default=default, string.trim(x))
+  end
+
+  getter.map.memoize(f, x)
+end
+
+%ifndef file.metadata.flac
+let file.metadata.flac = fun (_) -> []
+%endif
+
+let file.metadata.flac.cover = ()
+
+# Decode a flac-encoded cover metadata string.
+# @category String
+def file.metadata.flac.cover.decode(s) =
+  # See https://xiph.org/flac/format.html#metadata_block_picture
+  i = ref(0)
+
+  def read_int() =
+    ret =
+      string.binary.to_int(
+        little_endian=false,
+        string.sub(encoding="ascii", s, start=i(), length=4)
+      )
+
+    i := i() + 4
+    ret
+  end
+
+  def read_string(len) =
+    ret = string.sub(encoding="ascii", s, start=i(), length=len)
+    i := i() + len
+    (ret : string)
+  end
+
+  pic_type = read_int()
+  mime_len = read_int()
+  mime = mime_len == 0 ? "image/" : read_string(mime_len)
+  desc_len = read_int()
+  desc = read_string(desc_len)
+  width = read_int()
+  height = read_int()
+  color_depth = read_int()
+  number_of_colors = read_int()
+  number_of_colors = number_of_colors > 0 ? null(number_of_colors) : null
+  data_len = read_int()
+  data = string.sub(encoding="ascii", s, start=i(), length=data_len)
+  if
+    data == ""
+  then
+    log.info(
+      "Failed to read cover metadata"
+    )
+    null
+  else
+    null(
+      data.{
+        picture_type = pic_type,
+        mime = mime,
+        description = desc,
+        width = width,
+        height = height,
+        color_depth = color_depth,
+        number_of_colors = number_of_colors
+      }
+    )
+  end
+end
+
+# Encode cover metadata for embedding with flac files.
+# @category String
+def file.metadata.flac.cover.encode(
+  ~picture_type,
+  ~mime,
+  ~description="",
+  ~width,
+  ~height,
+  ~color_depth,
+  ~number_of_colors=null,
+  data
+) =
+  def encode_string(s) =
+    len = 1 + (string.bytes.length(s) / 8)
+    str_len = string.binary.of_int(little_endian=false, pad=4, len)
+    if
+      string.bytes.length(str_len) > 4
+    then
+      error.raise(
+        error.invalid,
+        "Data length too long for APIC format!"
+      )
+    end
+
+    pad = string.make(char_code=0, len * 8 - string.bytes.length(s))
+    (str_len, "#{s}#{pad}")
+  end
+
+  pic_type = string.binary.of_int(little_endian=false, pad=4, picture_type)
+  let (mime_len, mime) = encode_string(mime)
+  let (desc_len, description) = encode_string(description)
+  width = string.binary.of_int(little_endian=false, pad=4, width)
+  height = string.binary.of_int(little_endian=false, pad=4, height)
+  color_depth = string.binary.of_int(little_endian=false, pad=4, color_depth)
+  number_of_colors =
+    string.binary.of_int(little_endian=false, pad=4, number_of_colors ?? 0)
+
+  let (data_len, data) = encode_string(data)
+  "#{pic_type}#{mime_len}#{mime}#{desc_len}#{description}#{width}#{height}#{
+    color_depth
+  }#{number_of_colors}#{data_len}#{data}"
+end
+
+# Download file using a regular http.get request. Returns `true` on success.
+# @category File
+# @param ~filename Downloaded filename.
+# @param ~timeout Timeout in seconds
+def file.download(~filename, ~timeout=5., url) =
+  file_writer = file.write.stream(filename)
+  response = http.get.stream(on_body_data=file_writer, timeout=timeout, url)
+  response.status_code < 400
+end

--- a/tests/liq/getter.liq
+++ b/tests/liq/getter.liq
@@ -1,0 +1,74 @@
+# Construct a function returning the value of a getter.
+# @category Getter
+def getter.function(x) =
+  {getter.get(x)}
+end
+
+# Determine if a getter is a constant.
+# @category Getter
+def getter.is_constant(x) =
+  getter.case(x, fun (_) -> true, fun (_) -> false)
+end
+
+# Convert an int getter to a float getter.
+# @category Getter
+def getter.float_of_int(x) =
+  getter.map(float_of_int, x)
+end
+
+# Convert a float getter to a int getter.
+# @category Getter
+def getter.int_of_float(x) =
+  getter.map(int_of_float, x)
+end
+
+# Execute a function when the value of the getter changes.
+# @category Getter
+def getter.on_change(f, x) =
+  x = {getter.get(x)}
+  old = ref(x())
+  fun () ->
+    begin
+      new = x()
+      if
+        old() != new
+      then
+        old := new
+        f(new)
+      end
+
+      new
+    end
+end
+
+# Detect whether the value of the getter changes.
+# @category Getter
+def getter.changes(x) =
+  old = ref(getter.get(x))
+  fun () ->
+    begin
+      new = getter.get(x)
+      if
+        old() != new
+      then
+        old := new
+        true
+      else
+        false
+      end
+    end
+end
+
+# Give the latest value among two getters.
+# @category Getter
+def getter.merge(x, y) =
+  v = ref(getter.get(x))
+  x = getter.on_change(fun (x) -> v := x, x)
+  y = getter.on_change(fun (y) -> v := y, y)
+  fun () ->
+    begin
+      ignore(x())
+      ignore(y())
+      v()
+    end
+end

--- a/tests/liq/hls.liq
+++ b/tests/liq/hls.liq
@@ -1,0 +1,329 @@
+let hls = {playlist = ()}
+
+# Generate a main HLS playlist
+# @category String
+def hls.playlist.main(~extra_tags=[], ~prefix="", ~version=7, streams) =
+  prefix = prefix == "" or r/\/$/.test(prefix) ? prefix : "#{prefix}/"
+
+  streams =
+    list.fold(
+      fun (streams, s) ->
+        begin
+          let ({bandwidth, codecs, video_size?, ...s} :
+            string.{ bandwidth: int, codecs: string, video_size?: (int * int) }
+          ) = s
+          resolution =
+            if
+              null.defined(video_size)
+            then
+              let (w, h) = null.get(video_size)
+              ",RESOLUTION=#{w}x#{h}"
+            else
+              ""
+            end
+
+          [
+            ...streams,
+            "#EXT-X-STREAM-INF:BANDWIDTH=#{bandwidth},CODECS=#{
+              string.quote(codecs)
+            }#{resolution}",
+            "#{prefix}#{s}.m3u8"
+          ]
+        end,
+      [],
+      streams
+    )
+
+  string.concat(
+    separator="\r\n",
+    ["#EXTM3U", "#EXT-X-VERSION:#{version}", ...extra_tags, ...streams, ""]
+  )
+end
+
+# @docof output.file.hls
+def replaces output.file.hls(
+  %argsof(output.file.hls[!main_playlist_writer]),
+  ~main_playlist_writer=null(
+    fun (~extra_tags, ~prefix, ~version, streams) ->
+      null(
+        hls.playlist.main(
+          extra_tags=extra_tags,
+          prefix=prefix,
+          version=version,
+          streams
+        )
+      )
+  ),
+  dir,
+  streams,
+  s
+) =
+  output.file.hls(
+    %argsof(output.file.hls[!main_playlist_writer]),
+    main_playlist_writer=main_playlist_writer,
+    dir,
+    streams,
+    s
+  )
+end
+
+let input.hls = ()
+
+# Play an HLS stream.
+# @category Source / Input / Active
+# @param ~id Force the value of the source ID.
+# @param ~reload How often (in seconds) the playlist should be reloaded.
+# @param uri Playlist URI.
+# @flag experimental
+def input.hls.native(~id=null, ~reload=10., uri) =
+  playlistr = ref([])
+  sequence = ref(0)
+  playlist_uri = ref(uri)
+  id = string.id.default(default="input.hls.native", id)
+
+  def load_playlist() =
+    pl = request.create(playlist_uri())
+    if
+      request.resolve(pl)
+    then
+      pl = request.filename(pl)
+      m = r/#EXT-X-MEDIA-SEQUENCE:(\d+)/.exec(file.contents(pl))
+      pl_sequence = m[1]
+      log.info(
+        label=id,
+        "Sequence: " ^
+          pl_sequence
+      )
+      pl_sequence = int_of_string(default=0, pl_sequence)
+      files = playlist.parse(path=path.dirname(playlist_uri()) ^ "/", pl)
+
+      def file_request(idx, el) =
+        let (meta, file) = el
+
+        def escape(s) =
+          string.escape(encoding="ascii", s)
+        end
+
+        s =
+          list.fold(
+            fun (cur, el) -> "#{cur},#{fst(el)}=#{escape(snd(el))}",
+            "",
+            meta
+          )
+
+        s = if s == "" then file else "annotate:#{s}:#{file}" end
+        (pl_sequence + idx, s)
+      end
+
+      files = list.mapi(file_request, files)
+      let (first_idx, _) = list.hd(default=(-1, ""), playlistr())
+
+      def add_file(playlist, file) =
+        let (idx, _) = file
+        if
+          first_idx < idx and not list.assoc.mem(idx, playlist)
+        then
+          list.append(playlist, [file])
+        else
+          playlist
+        end
+      end
+
+      playlistr := list.fold(add_file, playlistr(), files)
+    else
+      log.severe(
+        label=id,
+        "Couldn't read playlist: request resolution failed."
+      )
+      playlistr := []
+    end
+
+    request.destroy(pl)
+  end
+
+  def rec next() =
+    if
+      list.length(playlistr()) > 0
+    then
+      let (_, ret) = list.hd(default=(1, ""), playlistr())
+      playlistr := list.tl(playlistr())
+      sequence := sequence() + 1
+      request.create(ret)
+    else
+      null
+    end
+  end
+
+  def find_stream() =
+    pl = request.create(playlist_uri())
+    if
+      request.resolve(pl)
+    then
+      plfile = request.filename(pl)
+      m =
+        r/#EXT-X-STREAM-INF[^\n]*\n([^\r\n]*)\r?\n/.exec(file.contents(plfile))
+
+      playlist_uri := list.assoc(default=playlist_uri(), 1, m)
+      if
+        not (string.contains(substring="/", playlist_uri()))
+      then
+        playlist_uri := path.dirname(request.uri(pl)) ^ "/" ^ playlist_uri()
+      end
+
+      log(
+        label=id,
+        "Playlist: " ^
+          playlist_uri()
+      )
+    end
+  end
+
+  find_stream()
+  s = request.dynamic(id=id, prefetch=10, next)
+  let {track_marks = _, ...tracks} = source.tracks(s)
+  s = source(tracks)
+  thread.run(every=reload, load_playlist)
+  s
+end
+
+let replaces input.hls = input.hls.native
+%ifdef input.ffmpeg
+let replaces input.hls = input.ffmpeg
+%endif
+
+# Play an HLS stream.
+# @category Source / Input / Active
+# @param ~id Force the value of the source ID.
+# @param uri Playlist URI.
+def input.hls(~id=null, uri) =
+  input.hls(id=id, uri)
+end
+
+let output.harbor.hls = ()
+
+# @flag hidden
+def output.harbor.hls.base(
+  %argsof(output.file.hls[!segment_name]),
+  ~segment_name,
+  ~tmpdir,
+  ~port,
+  ~path,
+  serve,
+  formats,
+  s
+) =
+  tmpdir = tmpdir ?? file.temp_dir("hls", "")
+
+  def content_type(fname) =
+    ext = file.extension(fname)
+    if
+      ext == ".m3u8"
+    then
+      "application/x-mpegURL"
+    else
+      def f(cur, el) =
+        format = snd(el)
+        if
+          ext == ".#{encoder.extension(format)}"
+        then
+          encoder.content_type(format)
+        else
+          cur
+        end
+      end
+
+      list.fold(f, "", formats)
+    end
+  end
+
+  serve(port=port, path=path, content_type=content_type, tmpdir)
+  output.file.hls(%argsof(output.file.hls), tmpdir, formats, s)
+end
+
+# Output the source stream to an HTTP live stream served from the harbor HTTP server.
+# @category Source / Output
+# @argsof output.file.hls
+# @param ~headers Default response headers.
+# @param ~port Port for incoming harbor (http) connections.
+# @param ~path Base path for hls URIs.
+# @param ~transport Http transport. Use `http.transport.ssl` or `http.transport.secure_transport`, when available, to enable HTTPS output
+# @param ~tmpdir Directory for generated files.
+# @param formats List of specifications for each stream: (name, format).
+def replaces output.harbor.hls(
+  %argsof(output.file.hls[!segment_name]),
+  ~segment_name=(
+    fun (metadata) ->
+      "#{metadata.stream_name}_#{metadata.position}.#{metadata.extname}"
+  ),
+  ~headers=[("Access-Control-Allow-Origin", "*")],
+  ~port=8000,
+  ~path="/",
+  ~tmpdir=null,
+  ~transport=http.transport.unix,
+  formats,
+  s
+) =
+  def serve(~port, ~path, ~content_type, dir) =
+    harbor.http.static(
+      port=port,
+      path=path,
+      content_type=content_type,
+      headers=headers,
+      transport=transport,
+      dir
+    )
+  end
+
+  output.harbor.hls.base(
+    %argsof(output.file.hls),
+    path=path,
+    port=port,
+    tmpdir=tmpdir,
+    serve,
+    formats,
+    s
+  )
+end
+
+%ifdef harbor.https.static
+# Output the source stream to an HTTP live stream served from the harbor HTTPS server.
+# @category Source / Output
+# @param ~headers Default response headers.
+# @param ~port Port for incoming harbor (http) connections.
+# @param ~path Base path for hls URIs.
+# @param ~tmpdir Directory for generated files.
+# @param formats List of specifications for each stream: (name, format).
+def output.harbor.hls.https(
+  %argsof(output.file.hls[!segment_name]),
+  ~segment_name=(
+    fun (metadata) ->
+      "#{metadata.stream_name}_#{metadata.position}.#{metadata.extname}"
+  ),
+  ~headers=[("Access-Control-Allow-Origin", "*")],
+  ~port=8000,
+  ~path="/",
+  ~tmpdir=null,
+  formats,
+  s
+) =
+  def serve(~port, ~path, ~content_type, dir) =
+    harbor.https.static(
+      port=port,
+      path=path,
+      content_type=content_type,
+      headers=headers,
+      dir
+    )
+  end
+
+  output.harbor.hls.base(
+    %argsof(output.file.hls),
+    path=path,
+    port=port,
+    tmpdir=tmpdir,
+    serve,
+    formats,
+    s
+  )
+end
+%endif

--- a/tests/liq/http.liq
+++ b/tests/liq/http.liq
@@ -1,0 +1,1048 @@
+# Set of HTTP utils.
+
+# Prepare a list of `(string, string)` arguments for
+# sending as `"application/x-www-form-urlencoded"` content
+# @category Internet
+def http.www_form_urlencoded(params) =
+  params =
+    list.map(
+      fun (v) ->
+        begin
+          let (key, value) = v
+          "#{url.encode(key)}=#{url.encode(value)}"
+        end,
+      params
+    )
+
+  string.concat(separator="&", params)
+end
+
+# Prepare a list of data to be sent as multipart form data.
+# @category Internet
+# @param ~boundary Specify boundary to use for multipart/form-data.
+# @param data data to insert
+def http.multipart_form_data(~boundary=null, data) =
+  def default_boundary() =
+    range = [...string.char.ascii.alphabet, ...string.char.ascii.number]
+    l = list.init(12, fun (_) -> string.char.ascii.random(range))
+    string.concat(l)
+  end
+
+  boundary = null.default(boundary, default_boundary)
+
+  def mk_content(contents, entry) =
+    data = entry.contents
+    attributes = [("name", entry.name), ...entry.attributes]
+    attributes =
+      list.map(
+        fun (v) -> "#{string(fst(v))}=#{string.quote(snd(v))}",
+        attributes
+      )
+
+    attributes =
+      string.concat(
+        separator="; ",
+        attributes
+      )
+    headers =
+      list.map(
+        fun (v) ->
+          "#{string(fst(v))}: #{string(snd(v))}",
+        entry.headers
+      )
+
+    headers = string.concat(separator="\r\n", headers)
+    headers = headers == "" ? "" : "#{headers}\r\n"
+
+    # This is for typing purposes
+    (entry : unit)
+    [
+      ...contents,
+      getter("--#{boundary}\r\n"),
+      getter(
+        "Content-Disposition: form-data; #{attributes}\r\n"
+      ),
+      getter(headers),
+      getter("\r\n"),
+      data,
+      getter("\r\n")
+    ]
+  end
+
+  contents = [...list.fold(mk_content, [], data), getter("--#{boundary}--\r\n")]
+  contents = string.getter.concat(contents)
+  contents =
+    if
+      list.for_all(fun (entry) -> getter.is_constant(entry.contents), data)
+    then
+      getter(string.getter.flush(contents))
+    else
+      contents
+    end
+
+  {contents = contents, boundary = boundary}
+end
+
+# Initiate a response handler with pre-filled values.
+# @category Internet
+# @method content_type Set `"Content-Type"` header
+# @method data Set response data.
+# @method headers Replace response headers.
+# @method header Set a single header on the response
+# @method json Set content-type to json and data to `json.stringify` of the argument
+# @method redirect Set `status_code` and `Location:` header for a HTTP redirect response
+# @method html Set content-type to html and data to argument value
+# @method http_version Set http protocol version
+# @method status_code Set response status code
+# @method status_message Set response status message
+def http.response(
+  ~http_version="1.1",
+  ~status_code=null,
+  ~status_message=null,
+  ~headers=[],
+  ~content_type=null,
+  ~data=getter("")
+) =
+  status_code =
+    status_code
+      ?? if
+        http_version == "1.1"
+        and headers["expect"] == "100-continue"
+        and getter.get(data) == ""
+      then
+        100
+      else
+        200
+      end
+
+  http_version = ref(http_version)
+  status_code = ref(status_code)
+  status_message = ref(status_message)
+  headers = ref(headers)
+  content_type = ref(content_type)
+  data = ref(data)
+  status_sent = ref(false)
+  headers_sent = ref(false)
+  data_sent = ref(false)
+  response_ended = ref(false)
+
+  def mk_status() =
+    status_sent := true
+    http_version = http_version()
+    status_code = status_code()
+    status_code =
+      if
+        status_code == 100 and getter.get(data()) != ""
+      then
+        200
+      else
+        status_code
+      end
+
+    status_message = status_message() ?? http.codes[status_code]
+    "HTTP/#{http_version} #{status_code} #{status_message}\r\n"
+  end
+
+  def mk_headers() =
+    headers_sent := true
+    headers = headers()
+    content_type = content_type()
+    data = data()
+    headers =
+      if
+        getter.is_constant(data)
+      then
+        data = getter.get(data)
+        len = string.bytes.length(data)
+        if
+          data != ""
+        then
+          ("Content-Length", "#{len}")::headers
+        else
+          headers
+        end
+      else
+        ("Transfer-Encoding", "chunked")::headers
+      end
+
+    headers =
+      if
+        null.defined(content_type) and null.get(content_type) != ""
+      then
+        ("Content-type", null.get(content_type))::headers
+      else
+        headers
+      end
+
+    headers =
+      list.map(
+        fun (v) ->
+          "#{fst(v)}: #{snd(v)}",
+        headers
+      )
+    headers = string.concat(separator="\r\n", headers)
+    headers = if headers != "" then "#{headers}\r\n" else "" end
+    "#{headers}\r\n"
+  end
+
+  def mk_data() =
+    data_sent := true
+    data = data()
+    if
+      getter.is_constant(data)
+    then
+      response_ended := true
+      getter.get(data)
+    else
+      data = getter.get(data)
+      len = string.bytes.length(data)
+      response_ended := data == ""
+      "#{string.hex_of_int(len)}\r\n#{data}\r\n"
+    end
+  end
+
+  def response() =
+    if
+      response_ended()
+    then
+      ""
+    elsif
+      not status_sent()
+    then
+      mk_status()
+    elsif
+      not headers_sent()
+    then
+      mk_headers()
+    else
+      mk_data()
+    end
+  end
+
+  def attr_method(sent, attr) =
+    def set(v) =
+      if
+        sent()
+      then
+        error.raise(
+          error.invalid,
+          "HTTP response has already been sent for this value!"
+        )
+      end
+
+      attr := v
+    end
+
+    def get() =
+      attr()
+    end
+
+    set.{current = get}
+  end
+
+  def header(k, v) =
+    headers := (k, v)::headers()
+  end
+
+  code = status_code
+
+  def redirect(~status_code=301, location) =
+    if
+      status_sent()
+    then
+      error.raise(
+        error.invalid,
+        "HTTP response has already been sent for this value!"
+      )
+    end
+
+    code := status_code
+    header("Location", location)
+  end
+
+  def json(~compact=true, v) =
+    if
+      headers_sent()
+    then
+      error.raise(
+        error.invalid,
+        "HTTP response has already been sent for this value!"
+      )
+    end
+
+    content_type :=
+      "application/json; charset=utf-8"
+    data := json.stringify(v, compact=compact) ^ "\n"
+  end
+
+  def html(d) =
+    if
+      headers_sent()
+    then
+      error.raise(
+        error.invalid,
+        "HTTP response has already been sent for this value!"
+      )
+    end
+
+    content_type := "text/html"
+    data := d
+  end
+
+  def send_status(socket) =
+    if not status_sent() then socket.write(mk_status()) end
+  end
+
+  def multipart_form(~boundary=null, contents) =
+    if
+      headers_sent()
+    then
+      error.raise(
+        error.invalid,
+        "HTTP response has already been sent for this value!"
+      )
+    end
+
+    form_data = http.multipart_form_data(boundary=boundary, contents)
+    content_type :=
+      "multipart/form-data; boundary=#{form_data.boundary}"
+    data := form_data.contents
+  end
+
+  response.{
+    http_version = attr_method(status_sent, http_version),
+    status_code = attr_method(status_sent, status_code),
+    status_message = attr_method(status_sent, status_message),
+    headers = attr_method(headers_sent, headers),
+    header = header,
+    redirect = redirect,
+    json = json,
+    html = html,
+    content_type = attr_method(headers_sent, content_type),
+    multipart_form = multipart_form,
+    data = attr_method(data_sent, data),
+    send_status = send_status,
+    status_sent = {status_sent()}
+  }
+end
+
+# @flag hidden
+def harbor.http.regexp_of_path(path) =
+  def named_capture(s) =
+    name =
+      string.sub(
+        encoding="ascii",
+        s,
+        start=1,
+        length=string.bytes.length(s) - 1
+      )
+    "(?<#{name}>[^/]+)"
+  end
+
+  rex = r/:[\w_]+/g.replace(named_capture, path)
+  regexp("^#{rex}$")
+end
+
+# @flag hidden
+def harbor.http.mk_body(get_data) =
+  done = ref(false)
+  data = ref("")
+
+  def body(~timeout=10.) =
+    if
+      done()
+    then
+      data()
+    else
+      start_time = time()
+
+      def rec read() =
+        if
+          done()
+        then
+          data()
+        else
+          if
+            start_time + timeout < time()
+          then
+            error.raise(error.http, "Timeout!")
+          end
+
+          r = get_data(timeout=timeout)
+          if
+            r == ""
+          then
+            data()
+          else
+            data := "#{data()}#{r}"
+            read()
+          end
+        end
+      end
+
+      read()
+    end
+  end
+
+  body
+end
+
+# Register a HTTP handler on the harbor. This function offers a simple API,
+# suitable for quick implementation of HTTP handlers. See `harbor.http.register`
+# for a node/express like alternative API.
+# @category Internet
+# @argsof harbor.http.register
+def harbor.http.register.simple(%argsof(harbor.http.register), path, handler) =
+  def handler(request) =
+    def data(~timeout=10.) =
+      request.data(timeout=timeout)
+    end
+
+    handler(request.{data = data, body = harbor.http.mk_body(data)})
+  end
+
+  harbor.http.register(
+    %argsof(harbor.http.register),
+    harbor.http.regexp_of_path(path),
+    handler
+  )
+end
+
+# Register a HTTP handler on the harbor with a generic regexp `path`. This function offers a simple API,
+# suitable for quick implementation of HTTP handlers. See `harbor.http.register`
+# for a node/express like alternative API.
+# @category Internet
+# @argsof harbor.http.register
+def harbor.http.register.simple.regexp(
+  %argsof(harbor.http.register),
+  path,
+  handler
+) =
+  harbor.http.register(%argsof(harbor.http.register), path, handler)
+end
+
+# @flag hidden
+let harbor.http.middleware = ref(fun (req, res, next) -> next(req, res))
+
+# Register a new harbor middleware
+# @category Internet
+def harbor.http.middleware.register(fn) =
+  middleware = harbor.http.middleware()
+  harbor.http.middleware :=
+    fun (req, res, next) ->
+      begin middleware(req, res, fun (res, res) -> fn(req, res, next)) end
+end
+
+# @flag hidden
+def harbor.http.register.regexp(%argsof(harbor.http.register), path, handler) =
+  def handler(request) =
+    response = http.response(http_version=request.http_version)
+    is_response_done = ref(false)
+
+    def replaces response() =
+      ret = response()
+      is_response_done := ret == ""
+      ret
+    end
+
+    def data(~timeout=10.) =
+      if
+        is_response_done()
+      then
+        error.raise(
+          error.http,
+          "Response ended!"
+        )
+      end
+      if
+        response.status_code.current() == 100 and not response.status_sent()
+      then
+        response.send_status(request.socket)
+      end
+
+      request.data(timeout=timeout)
+    end
+
+    request =
+      {
+        body = harbor.http.mk_body(data),
+        data = data,
+        headers = request.headers,
+        http_version = request.http_version,
+        method = request.method,
+        path = request.path,
+        query = request.query
+      }
+
+    handler =
+      fun (req, res) ->
+        begin
+          middleware = harbor.http.middleware()
+          middleware(req, res, fun (req, res) -> handler(req, res))
+        end
+
+    (handler(request, response) : unit)
+    response
+  end
+
+  harbor.http.register(%argsof(harbor.http.register), path, handler)
+end
+
+def replaces harbor.http.middleware =
+  ()
+end
+
+# Register a HTTP handler on the harbor. The handler function
+# receives as argument the full requested information and returns the
+# answer sent to the client, including HTTP headers. This function
+# registers exact path matches, i.e. `"/users"`, `"/index.hml"`
+# as well as fragment matches, i.e. `"/user/:id"`, `"/users/:id/collabs/:cid"`,
+# etc. If you need more advanced matching, use `harbor.http.register.regexp`
+# to match regular expressions. Paths are resolved in the order they are declared
+# and can override default harbor paths such as metadata handlers.
+# The handler receives the request details as a record and a response
+# handler. Matched fragments are reported as part of the response `query` parameter.
+# The response handler can be used to fill up details about the http response,
+# which will be converted into a plain HTTP response string after the handler returns.
+# @category Internet
+# @argsof harbor.http.register
+def replaces harbor.http.register(
+  %argsof(harbor.http.register),
+  path,
+  handler
+) =
+  harbor.http.register.regexp(
+    %argsof(harbor.http.register),
+    harbor.http.regexp_of_path(path),
+    handler
+  )
+end
+
+let harbor.http.static = ()
+
+# @flag hidden
+def harbor.http.static.base(
+  serve,
+  ~content_type,
+  ~basepath,
+  ~headers,
+  ~browse,
+  directory
+) =
+  directory = path.home.unrelate(directory)
+  basepath = if r/^\//.test(basepath) then basepath else "/#{basepath}" end
+  basepath = if r/\/$/.test(basepath) then basepath else "#{basepath}/" end
+
+  def handler(request, response) =
+    response.headers(headers)
+    rpath = string.residual(prefix=basepath, request.path)
+    if
+      not null.defined(rpath)
+    then
+      response.status_code(404)
+    else
+      rpath = url.decode(null.get(rpath))
+      fname = path.concat(directory, rpath)
+      log.debug(
+        "Serving static file: #{fname}"
+      )
+      if
+        not file.exists(fname)
+      then
+        response.status_code(404)
+      else
+        if
+          file.is_directory(fname)
+        then
+          if
+            not browse
+          then
+            response.status_code(403)
+          else
+            page = ref("")
+            base_url =
+              if
+                r/\/$/.test(request.path)
+              then
+                request.path
+              else
+                request.path ^ "/"
+              end
+
+            def add(s) =
+              page := page() ^ s ^ "\n"
+            end
+
+            def add_file(f) =
+              add(
+                "<li><a href=\"#{base_url}#{url.encode(f)}\">#{f}</a></li>"
+              )
+            end
+
+            add("<html><body><ul>")
+            list.iter(add_file, file.ls(sorted=true, fname))
+            add("</ul></body>")
+            response.content_type(
+              "text/html; charset=UTF-8"
+            )
+            response.data(string.getter.single(page()))
+          end
+        else
+          mime = content_type(fname)
+          if null.defined(mime) then response.content_type(null.get(mime)) end
+          if request.method == "GET" then response.data(file.read(fname)) end
+        end
+      end
+    end
+  end
+
+  basepath = "#{basepath}.*"
+
+  def register(method) =
+    serve(method=method, basepath, handler)
+  end
+
+  list.iter(register, ["OPTIONS", "HEAD", "GET"])
+end
+
+# It seems that browsers want a trailing 0 for floats.
+# @flag hidden
+def http.string_of_float(x) =
+  s = string(x)
+  if r/\.$/.test(s) then "#{s}0" else s end
+end
+
+# @flag hidden
+def get_mime_process(file) =
+  mime =
+    list.hd(
+      default="",
+      process.read.lines(
+        "file -b -I #{process.quote(file)}"
+      )
+    )
+
+  if mime == "" then null else mime end
+end
+
+# @flag hidden
+content_type = get_mime_process
+%ifdef file.mime
+# @flag hidden
+content_type = file.mime
+%endif
+
+# Serve a static path.
+# @category Internet
+# @param ~port Port for incoming harbor (http) connections.
+# @param ~transport Http transport. Use `http.transport.ssl` or http.transport.secure_transport`, when available, to enable HTTPS output
+# @param ~path Base path.
+# @param ~headers Default response headers.
+# @param ~browse List files in directories.
+# @param ~content_type Callback to specify Content-Type on a per file basis. Default: file.mime if compiled or file CLI if present.
+# @param directory Local path to be served.
+def replaces harbor.http.static(
+  ~transport=http.transport.unix,
+  ~port=8000,
+  ~path="/",
+  ~browse=false,
+  ~content_type=(content_type : (string)->string?),
+  ~headers=[("Access-Control-Allow-Origin", "*")],
+  directory
+) =
+  # Make the method argument non-optional, see #1018
+  serve =
+    fun (~method, uri, handler) ->
+      harbor.http.register(
+        transport=transport,
+        port=port,
+        method=method,
+        uri,
+        handler
+      )
+
+  harbor.http.static.base(
+    serve,
+    content_type=content_type,
+    basepath=path,
+    browse=browse,
+    headers=headers,
+    directory
+  )
+end
+
+# @flag hidden
+stdlib_file = file
+
+# @flag hidden
+upload_file_fn =
+  fun (
+    ~name,
+    ~content_type,
+    ~headers,
+    ~boundary,
+    ~filename,
+    ~file,
+    ~contents,
+    ~timeout,
+    ~redirect,
+    url,
+    fn
+  ) ->
+    begin
+      if
+        not null.defined(filename) and not null.defined(file)
+      then
+        error.raise(
+          error.http,
+          "At least one of: `file` or `filename` must be defined!"
+        )
+      end
+
+      if
+        null.defined(file) and null.defined(contents)
+      then
+        error.raise(
+          error.http,
+          "Only one of: `contents` or `file` must be defined!"
+        )
+      end
+
+      # Massage parameters
+      filename =
+        null.defined(filename)
+          ? null.get(filename)
+          : string(path.basename(null.get(file)))
+
+      contents =
+        null.defined(contents)
+          ? null.get(contents)
+          : getter(stdlib_file.read(null.get(file)))
+
+      # Create query
+      content_type = content_type ?? "application/octet-stream"
+      data =
+        http.multipart_form_data(
+          boundary=boundary,
+          [
+            {
+              name = name,
+              attributes = [("filename", filename)],
+              headers = [("Content-Type", content_type)],
+              contents = contents
+            }
+          ]
+        )
+
+      headers =
+        (
+          "Content-Type",
+          "multipart/form-data; boundary=#{data.boundary}"
+        )::headers
+
+      fn(
+        headers=headers,
+        timeout=timeout,
+        redirect=redirect,
+        data=data.contents,
+        url
+      )
+    end
+
+# Send a file via POST request encoded in multipart/form-data. The contents can
+# either be directly specified (with the `contents` argument) or taken from a
+# file (with the `file` argument).
+# @category Internet
+# @param ~name Name of the field field
+# @param ~content_type Content-type (mime) for the file.
+# @param ~headers Additional headers.
+# @param ~boundary Specify boundary to use for multipart/form-data.
+# @param ~filename File name sent in the request.
+# @param ~file File whose contents is to be sent in the request.
+# @param ~contents Contents of the file sent in the request.
+# @param ~timeout Timeout in seconds.
+# @param ~redirect Follow reidrections.
+# @param url URL to post to.
+def http.post.file(
+  ~name="file",
+  ~content_type=null,
+  ~headers=[],
+  ~boundary=null,
+  ~filename=null,
+  ~file=null,
+  ~contents=null,
+  ~timeout=null,
+  ~redirect=true,
+  url
+) =
+  upload_file_fn(
+    name=name,
+    content_type=content_type,
+    headers=headers,
+    boundary=boundary,
+    filename=filename,
+    file=file,
+    contents=contents,
+    timeout=timeout,
+    redirect=redirect,
+    url,
+    http.post
+  )
+end
+
+# Send a file via PUT request encoded in multipart/form-data. The contents can
+# either be directly specified (with the `contents` argument) or taken from a
+# file (with the `file` argument).
+# @category Internet
+# @param ~name Name of the field field
+# @param ~content_type Content-type (mime) for the file.
+# @param ~headers Additional headers.
+# @param ~boundary Specify boundary to use for multipart/form-data.
+# @param ~filename File name sent in the request.
+# @param ~file File whose contents is to be sent in the request.
+# @param ~contents Contents of the file sent in the request.
+# @param ~timeout Timeout in seconds.
+# @param ~redirect Follow reidrections.
+# @param url URL to put to.
+def http.put.file(
+  ~name="file",
+  ~content_type=null,
+  ~headers=[],
+  ~boundary=null,
+  ~filename=null,
+  ~file=null,
+  ~contents=null,
+  ~timeout=null,
+  ~redirect=true,
+  url
+) =
+  upload_file_fn(
+    name=name,
+    content_type=content_type,
+    headers=headers,
+    boundary=boundary,
+    filename=filename,
+    file=file,
+    contents=contents,
+    timeout=timeout,
+    redirect=redirect,
+    url,
+    http.put
+  )
+end
+
+let harbor.http.request = ()
+let settings.http.mime =
+  settings.make.void(
+    "MIME-related settings for HTTP requests"
+  )
+
+let settings.http.mime.extnames =
+  settings.make(
+    description="MIME to file extension mappings",
+    [
+      ("application/mp4", ".mp4"),
+      ("application/ogg", ".ogg"),
+      ("application/pdf", ".pdf"),
+      ("application/rss+xml", ".rss"),
+      ("application/smil", ".smil"),
+      ("application/smil+xml", ".smil"),
+      ("application/x-cue", ".cue"),
+      ("application/x-ogg", ".ogg"),
+      ("application/xspf+xml", ".xspf"),
+      ("audio/flac", ".flac"),
+      ("audio/mp3", ".mp3"),
+      ("audio/mp4", ".mp4"),
+      ("audio/mpeg", ".mp3"),
+      ("audio/mpegurl", ".m3u"),
+      ("audio/ogg", ".ogg"),
+      ("audio/vnd.wave", ".wav"),
+      ("audio/wav", ".wav"),
+      ("audio/wave", ".wav"),
+      ("audio/x-flac", ".flac"),
+      ("audio/x-mpegurl", ".m3u"),
+      ("audio/x-ogg", ".ogg"),
+      ("audio/x-scpls", ".pls"),
+      ("audio/x-wav", ".wav"),
+      ("image/bmp", ".bmp"),
+      ("image/jpeg", ".jpg"),
+      ("image/png", ".png"),
+      ("text/plain", ".txt"),
+      ("video/mp4", ".mp4"),
+      ("video/ogg", ".ogg"),
+      ("video/x-ms-asf", ".asf")
+    ]
+  )
+
+%ifndef file.mime
+let file.mime = ()
+%endif
+
+# Return the file extension associated with the given
+# content-type if it is known.
+# @category File
+def file.mime.extension(content_type) =
+  extnames = settings.http.mime.extnames()
+  extname = extnames[content_type]
+  extname == "" ? null : extname
+end
+
+let http.headers = ()
+
+# Extract the content-type header
+# @category Internet
+def http.headers.content_type(headers) =
+  mime =
+    try
+      list.find(
+        fun (v) ->
+          begin
+            let (header_name, _) = v
+            string.case(lower=true, header_name) == "content-type"
+          end,
+        headers
+      )
+    catch _ : [error.not_found] do
+      null
+    end
+
+  mime = null.map(snd, mime)
+  null.map(
+    fun (mime) ->
+      begin
+        let [mime, ...args] =
+          list.map(string.trim, string.split(separator=";", mime))
+
+        def parse_arg(arg) =
+          let [name, ...value] = string.split(separator="=", arg)
+          (name, string.unquote(string.concat(separator="=", value)))
+        end
+
+        {mime = mime, args = list.map(parse_arg, args)}
+      end,
+    mime
+  )
+end
+
+# Extract the content-disposition header
+# @category Internet
+def http.headers.content_disposition(headers) =
+  content_disposition =
+    try
+      list.find(
+        fun (v) ->
+          begin
+            let (header_name, _) = v
+            string.case(lower=true, header_name) == "content-disposition"
+          end,
+        headers
+      )
+    catch _ : [error.not_found] do
+      null
+    end
+
+  def parse_arg(arg) =
+    let [name, ...value] = string.split(separator="=", arg)
+    (name, string.unquote(string.concat(separator="=", value)))
+  end
+
+  def parse_filename(args) =
+    plain_filename = args["filename"]
+    plain_filename = plain_filename == "" ? null : plain_filename
+    encoded_filename = args["filename*"]
+    encoded_filename = encoded_filename == "" ? null : encoded_filename
+    encoded_filename =
+      null.map(
+        fun (encoded_filename) ->
+          begin
+            let [encoding, _, filename] =
+              string.split(separator="'", encoded_filename)
+
+            string.recode(in_enc=encoding, filename)
+          end,
+        encoded_filename
+      )
+
+    filename =
+      null.defined(encoded_filename) ? encoded_filename : plain_filename
+
+    filename =
+      null.map(fun (filename) -> url.decode(string.unquote(filename)), filename)
+
+    (
+      filename,
+      list.filter(
+        fun (v) -> fst(v) != "filename" and fst(v) != "filename*",
+        args
+      )
+    )
+  end
+
+  def parse_name(args) =
+    name = args["name"]
+    name = name == "" ? null : name
+    name = null.map(fun (name) -> url.decode(string.unquote(name)), name)
+    (name, list.filter(fun (v) -> fst(v) != "name", args))
+  end
+
+  null.map(
+    fun (v) ->
+      begin
+        let (_, header_value) = v
+        let [type, ...args] =
+          list.map(string.trim, string.split(separator=";", header_value))
+
+        args = list.map(parse_arg, args)
+        let (filename, args) = parse_filename(args)
+        let (name, args) = parse_name(args)
+        ({type = type, filename = filename, name = name, args = args} :
+          {
+            type: string,
+            filename?: string,
+            name?: string,
+            args: [(string * string?)]
+          }
+        )
+      end,
+    content_disposition
+  )
+end
+
+# Try to get a filename from a request's headers.
+# @category Internet
+def http.headers.extname(headers) =
+  content_disposition = http.headers.content_disposition(headers)
+  content_type = http.headers.content_type(headers)
+  extname =
+    if
+      null.defined(content_disposition?.filename)
+    then
+      extname = file.extension(null.get(content_disposition?.filename))
+      extname == "" ? null : extname
+    else
+      null
+    end
+
+  if
+    null.defined(extname)
+  then
+    extname
+  elsif
+    null.defined(content_type)
+  then
+    file.mime.extension(null.get(content_type).mime)
+  else
+    null
+  end
+end
+
+%ifdef input.harbor.dynamic.regexp
+# @docof input.harbor.dynamic.regexp
+# @argsof input.harbor.dynamic.regexp
+def replaces input.harbor.dynamic(%argsof(input.harbor.dynamic.regexp), path) =
+  input.harbor.dynamic.regexp(
+    %argsof(input.harbor.dynamic.regexp),
+    harbor.http.regexp_of_path(path)
+  )
+end
+%endif

--- a/tests/liq/http_codes.liq
+++ b/tests/liq/http_codes.liq
@@ -1,0 +1,447 @@
+# List of HTTP codes. Stolen from en.wikipedia.org.
+
+# List of HTTP response codes and statuses.
+# @category Interaction
+let http.codes =
+  [
+    (100, "Continue"),
+    #This means that the server has received the request headers, and that the client
+    #should proceed to send the request body (in the case of a request for which a
+    #body needs to be sent; for example, a POST request). If the request body is
+    #large, sending it to a server when a request has already been rejected based
+    #upon inappropriate headers is inefficient. To have a server check if the request
+    #could be accepted based on the request's headers alone, a client must send
+    #Expect: 100-continue as a header in its initial request and check if a 100
+    #Continue status code is received in response before continuing (or receive 417
+    #Expectation Failed and not continue).
+
+    (
+      101,
+      "Switching Protocols"
+    ),
+    #This means the requester has asked the server to switch protocols and the server
+    #is acknowledging that it will do so.
+
+    (102, "Processing"),
+    #As a WebDAV request may contain many sub-requests involving file operations, it
+    #may take a long time to complete the request. This code indicates that the
+    #server has received and is processing the request, but no response is available
+    #yet. This prevents the client from timing out and assuming the request was
+    #lost.
+
+    (
+      122,
+      "Request-URI too long"
+    ),
+    #This is a non-standard IE7-only code which means the URI is longer than a
+    #maximum of 2083 characters. (See code 414.),
+
+    #2xx Success
+
+    #This class of status codes indicates the action requested by the client was
+    #received, understood, accepted and processed successfully.
+
+    (200, "OK"),
+    #Standard response for successful HTTP requests. The actual response will depend
+    #on the request method used. In a GET request, the response will contain an
+    #entity corresponding to the requested resource. In a POST request the response
+    #will contain an entity describing or containing the result of the action.
+
+    (201, "Created"),
+    #The request has been fulfilled and resulted in a new resource being created.
+
+    (202, "Accepted"),
+    #The request has been accepted for processing, but the processing has not been
+    #completed. The request might or might not eventually be acted upon, as it might
+    #be disallowed when processing actually takes place.
+
+    (
+      203,
+      "Non-Authoritative Information"
+    ),
+    #The server successfully processed the request, but is returning information that
+    #may be from another source.
+
+    (
+      204,
+      "No Content"
+    ),
+    #The server successfully processed the request, but is not returning any
+    #content.
+
+    (
+      205,
+      "Reset Content"
+    ),
+    #The server successfully processed the request, but is not returning any content.
+    #Unlike a 204 response, this response requires that the requester reset the
+    #document view.
+
+    (
+      206,
+      "Partial Content"
+    ),
+    #The server is delivering only part of the resource due to a range header sent by
+    #the client. The range header is used by tools like wget to enable resuming of
+    #interrupted downloads, or split a download into multiple simultaneous
+    #streams.
+
+    (207, "Multi-Status"),
+    #The message body that follows is an XML message and can contain a number of
+    #separate response codes, depending on how many sub-requests were made.
+
+    (
+      226,
+      "IM Used"
+    ),
+    #The server has fulfilled a GET request for the resource, and the response is a
+    #representation of the result of one or more instance-manipulations applied to
+    #the current instance.
+
+    #3xx Redirection
+
+    #The client must take additional action to complete the request.
+    #This class of status code indicates that further action needs to be taken by the
+    #user agent in order to fulfil the request. The action required may be carried
+    #out by the user agent without interaction with the user if and only if the
+    #method used in the second request is GET or HEAD. A user agent should not
+    #automatically redirect a request more than five times, since such redirections
+    #usually indicate an infinite loop.
+
+    (
+      300,
+      "Multiple Choices"
+    ),
+    #Indicates multiple options for the resource that the client may follow. It, for
+    #instance, could be used to present different format options for video, list
+    #files with different extensions, or word sense disambiguation.
+
+    (
+      301,
+      "Moved Permanently"
+    ),
+    #This and all future requests should be directed to the given URI.
+
+    (302, "Found"),
+    #This is an example of industrial practice contradicting the standard.
+    #HTTP/1.0 specification (RFC 1945) required the client to perform a temporary
+    #redirect (the original describing phrase was "Moved Temporarily"), but
+    #popular browsers implemented 302 with the functionality of a 303 See Other.
+    #Therefore, HTTP/1.1 added status codes 303 and 307 to distinguish between the
+    #two behaviours. However, the majority of Web applications and frameworks
+    #still[as of?] use the 302 status code as if it were the 303.[citation needed]
+
+    (
+      303,
+      "See Other"
+    ),
+    #The response to the request can be found under another URI using a GET method.
+    #When received in response to a POST (or PUT/DELETE), it should be assumed that
+    #the server has received the data and the redirect should be issued with a
+    #separate GET message.
+
+    (
+      304,
+      "Not Modified"
+    ),
+    #Indicates the resource has not been modified since last requested. Typically,
+    #the HTTP client provides a header like the If-Modified-Since header to provide a
+    #time against which to compare. Using this saves bandwidth and reprocessing on
+    #both the server and client, as only the header data must be sent and received in
+    #comparison to the entirety of the page being re-processed by the server, then
+    #sent again using more bandwidth of the server and client.
+
+    (
+      305,
+      "Use Proxy"
+    ),
+    #Many HTTP clients (such as Mozilla and Internet Explorer) do not correctly
+    #handle responses with this status code, primarily for security reasons.
+
+    (
+      306,
+      "Switch Proxy"
+    ),
+    #No longer used.
+
+    (
+      307,
+      "Temporary Redirect"
+    ),
+    #In this occasion, the request should be repeated with another URI, but future
+    #requests can still use the original URI. In contrast to 303, the request
+    #method should not be changed when reissuing the original request. For instance,
+    #a POST request must be repeated using another POST request.
+
+    #4xx Client Error
+
+    #The 4xx class of status code is intended for cases in which the client seems to
+    #have erred. Except when responding to a HEAD request, the server should include
+    #an entity containing an explanation of the error situation, and whether it is a
+    #temporary or permanent condition. These status codes are applicable to any
+    #request method. User agents should display any included entity to the user.
+    #These are typically the most common error codes encountered while online.
+
+    (
+      400,
+      "Bad Request"
+    ),
+    #The request cannot be fulfilled due to bad syntax.
+
+    (401, "Unauthorized"),
+    #Similar to 403 Forbidden, but specifically for use when authentication is
+    #possible but has failed or not yet been provided. The response must include a
+    #WWW-Authenticate header field containing a challenge applicable to the requested
+    #resource. See Basic access authentication and Digest access authentication.
+
+    (
+      402,
+      "Payment Required"
+    ),
+    #Reserved for future use. The original intention was that this code might be
+    #used as part of some form of digital cash or micropayment scheme, but that has
+    #not happened, and this code is not usually used. As an example of its use,
+    #however, Apple's MobileMe service generates a 402 error (httpStatusCode:402" in
+    #the Mac OS X Console log) if the MobileMe account is delinquent.
+
+    (403, "Forbidden"),
+    #The request was a legal request, but the server is refusing to respond to it.
+    #Unlike a 401 Unauthorized response, authenticating will make no difference.
+
+    (
+      404,
+      "Not Found"
+    ),
+    #The requested resource could not be found but may be available again in the
+    #future. Subsequent requests by the client are permissible.
+
+    (
+      405,
+      "Method Not Allowed"
+    ),
+    #A request was made of a resource using a request method not supported by that
+    #resource; for example, using GET on a form which requires data to be
+    #presented via POST, or using PUT on a read-only resource.
+
+    (
+      406,
+      "Not Acceptable"
+    ),
+    #The requested resource is only capable of generating content not acceptable
+    #according to the Accept headers sent in the request.
+
+    (
+      407,
+      "Proxy Authentication Required"
+    ),
+    (
+      408,
+      "Request Timeout"
+    ),
+    #The server timed out waiting for the request. According to W3 HTTP
+    #specifications: "The client did not produce a request within the time that the
+    #server was prepared to wait. The client MAY repeat the request without
+    #modifications at any later time."
+
+    (409, "Conflict"),
+    #Indicates that the request could not be processed because of conflict in the
+    #request, such as an edit conflict.
+
+    (410, "Gone"),
+    #Indicates that the resource requested is no longer available and will not be
+    #available again. This should be used when a resource has been intentionally
+    #removed and the resource should be purged. Upon receiving a 410 status code, the
+    #client should not request the resource again in the future. Clients such as
+    #search engines should remove the resource from their indices. Most use cases do
+    #not require clients and search engines to purge the resource, and a "404 Not
+    #Found" may be used instead.
+
+    (
+      411,
+      "Length Required"
+    ),
+    #The request did not specify the length of its content, which is required by the
+    #requested resource.
+
+    (
+      412,
+      "Precondition Failed"
+    ),
+    #The server does not meet one of the preconditions that the requester put on the
+    #request.
+
+    (
+      413,
+      "Request Entity Too Large"
+    ),
+    #The request is larger than the server is willing or able to process.
+
+    (
+      414,
+      "Request-URI Too Long"
+    ),
+    #The URI provided was too long for the server to process.
+
+    (
+      415,
+      "Unsupported Media Type"
+    ),
+    #The request entity has a media type which the server or resource does not
+    #support. For example, the client uploads an image as image/svg+xml, but the
+    #server requires that images use a different format.
+
+    (
+      416,
+      "Requested Range Not Satisfiable"
+    ),
+    #The client has asked for a portion of the file, but the server cannot supply
+    #that portion. For example, if the client asked for a part of the file that
+    #lies beyond the end of the file.
+
+    (
+      417,
+      "Expectation Failed"
+    ),
+    #The server cannot meet the requirements of the Expect request-header field.
+
+    (
+      418,
+      "I'm a teapot"
+    ),
+    #This code was defined in 1998 as one of the traditional IETF April Fools' jokes,
+    #in RFC 2324, Hyper Text Coffee Pot Control Protocol, and is not expected to be
+    #implemented by actual HTTP servers.
+
+    (
+      422,
+      "Unprocessable Entity"
+    ),
+    #The request was well-formed but was unable to be followed due to semantic
+    #errors.
+
+    (423, "Locked"),
+    #The resource that is being accessed is locked.
+
+    (
+      424,
+      "Failed Dependency"
+    ),
+    #The request failed due to failure of a previous request (e.g. a PROPPATCH).
+
+    (
+      425,
+      "Unordered Collection"
+    ),
+    #Defined in drafts of "WebDAV Advanced Collections Protocol", but not present
+    #in "Web Distributed Authoring and Versioning (WebDAV) Ordered Collections
+    #Protocol".
+
+    (
+      426,
+      "Upgrade Required"
+    ),
+    #The client should switch to a different protocol such as TLS/1.0.
+
+    (
+      444,
+      "No Response"
+    ),
+    #A Nginx HTTP server extension. The server returns no information to the client
+    #and closes the connection (useful as a deterrent for malware).
+
+    (
+      449,
+      "Retry With"
+    ),
+    #A Microsoft extension. The request should be retried after performing the
+    #appropriate action.
+
+    (
+      450,
+      "Blocked by Windows Parental Controls"
+    ),
+    #A Microsoft extension. This error is given when Windows Parental Controls are
+    #turned on and are blocking access to the given webpage.
+
+    (
+      499,
+      "Client Closed Request"
+    ),
+    #An Nginx HTTP server extension. This code is introduced to log the case when the
+    #connection is closed by client while HTTP server is processing its request,
+    #making server unable to send the HTTP header back.
+
+    #5xx Server Error
+
+    #The server failed to fulfill an apparently valid request.
+    #Response status codes beginning with the digit "5" indicate cases in which the
+    #server is aware that it has encountered an error or is otherwise incapable of
+    #performing the request. Except when responding to a HEAD request, the server
+    #should include an entity containing an explanation of the error situation, and
+    #indicate whether it is a temporary or permanent condition. Likewise, user agents
+    #should display any included entity to the user. These response codes are
+    #applicable to any request method.
+
+    (
+      500,
+      "Internal Server Error"
+    ),
+    #A generic error message, given when no more specific message is suitable.
+
+    (
+      501,
+      "Not Implemented"
+    ),
+    #The server either does not recognise the request method, or it lacks the ability
+    #to fulfill the request.
+
+    (
+      502,
+      "Bad Gateway"
+    ),
+    #The server was acting as a gateway or proxy and received an invalid response
+    #from the upstream server.
+
+    (
+      503,
+      "Service Unavailable"
+    ),
+    #The server is currently unavailable (because it is overloaded or down for
+    #maintenance). Generally, this is a temporary state.
+
+    (
+      504,
+      "Gateway Timeout"
+    ),
+    #The server was acting as a gateway or proxy and did not receive a timely
+    #response from the upstream server.
+
+    (
+      505,
+      "HTTP Version Not Supported"
+    ),
+    #The server does not support the HTTP protocol version used in the request.
+
+    (
+      506,
+      "Variant Also Negotiates"
+    ),
+    #Transparent content negotiation for the request results in a circular
+    #reference.
+
+    (
+      507,
+      "Insufficient Storage"
+    ),
+    (
+      509,
+      "Bandwidth Limit Exceeded"
+    ),
+    #This status code, while used by many servers, is not specified in any RFCs.
+
+    (
+      510,
+      "Not Extended"
+    )
+    #Further extensions to the request are required for the server to fulfill it.
+  ]

--- a/tests/liq/icecast.liq
+++ b/tests/liq/icecast.liq
@@ -1,0 +1,58 @@
+%ifdef output.icecast
+# Encode and output the stream to a shoutcast server.
+# @category Source / Output
+# @argsof output.icecast[!method,!mount,!description,!protocol]
+# @param ~icy_reset Reset shoutcast source buffer upon connecting (necessary for NSV).
+# @param ~dj Set DJ name.
+# @param e Encoding format. Should be mp3 or AAC(+).
+# @param s The source to output
+def output.shoutcast(
+  %argsof(output.icecast[!method,!mount,!description,!protocol]),
+  ~icy_reset=true,
+  ~dj=getter(""),
+  ~aim="",
+  ~icq="",
+  ~irc="",
+  e,
+  s
+) =
+  icy_reset = if icy_reset then "1" else "0" end
+  headers =
+    [
+      ("icy-aim", aim),
+      ("icy-irc", irc),
+      ("icy-icq", icq),
+      ("icy-reset", icy_reset),
+      ...headers
+    ]
+
+  def map(m) =
+    dj = getter.get(dj)
+    if dj != "" then ("dj", dj)::m else m end
+  end
+
+  s = metadata.map(insert_missing=false, map, s)
+  output.icecast(
+    %argsof(output.icecast[!method,!mount,!headers,!description,!protocol]),
+    mount="",
+    headers=headers,
+    protocol="icy",
+    e,
+    s
+  )
+end
+
+# Encode and output the stream to an icecast server.
+# @category Source / Output
+# @argsof output.icecast[!protocol, !icy_id]
+# @param e Encoding format.
+# @param s The source to output
+def output.icecast(%argsof(output.icecast[!protocol,!icy_id]), e, s) =
+  output.icecast(
+    %argsof(output.icecast[!protocol,!icy_id]),
+    protocol="http",
+    e,
+    s
+  )
+end
+%endif

--- a/tests/liq/io.liq
+++ b/tests/liq/io.liq
@@ -1,0 +1,106 @@
+let replaces output = output.dummy
+%ifdef output.ao
+let replaces output = output.ao
+%endif
+
+%ifdef output.alsa
+let replaces output = output.alsa
+%endif
+
+%ifdef output.oss
+let replaces output = output.oss
+%endif
+
+%ifdef output.portaudio
+let replaces output = output.portaudio
+%endif
+
+%ifdef output.pulseaudio
+let replaces output = output.pulseaudio
+%endif
+
+# Output a stream using the default operator. The input source does not need to
+# be infallible, blank will just be played during failures.
+# @category Source / Output
+# @param ~id Force the value of the source ID.
+# @param ~fallible Allow the child source to fail, in which case the output will be (temporarily) stopped.
+# @param ~start Automatically start outputting whenever possible. If `true`, an infallible (normal) output will start as soon as it is created, and a fallible output will (re)start as soon as its source becomes available for streaming.
+# @param s Source to play.
+def replaces output(~id=null, ~fallible=true, ~start=true, s) =
+  output(id=id, fallible=fallible, start=start, s)
+end
+
+let output.video = output.dummy
+%ifdef output.sdl
+def output.video(%argsof(output.sdl), s) =
+  if
+    output.sdl.has_video()
+  then
+    (output.sdl(%argsof(output.sdl), s) : unit)
+  else
+    # Avoid using SDL when there is no video output.
+    (output.dummy(fallible=fallible, s) : unit)
+  end
+end
+%endif
+
+%ifdef output.graphics
+let output.video = output.graphics
+%endif
+
+# Output a video stream using the default operator. The input source does not
+# need to be infallible, blank will just be played during failures.
+# @category Source / Output
+# @param ~id Force the value of the source ID.
+# @param ~fallible Allow the child source to fail, in which case the output will be (temporarily) stopped.
+# @param ~start Automatically start outputting whenever possible. If `true`, an infallible (normal) output will start outputting as soon as it is created, and a fallible output will (re)start as soon as its source becomes available for streaming.
+# @param s Source to play.
+def output.video(~id=null, ~fallible=true, ~start=true, s) =
+  output.video(id=id, fallible=fallible, start=start, s)
+end
+
+# Output a stream with audio and video using the default operator. The input
+# source does not need to be infallible, blank will just be played during
+# failures.
+# @category Source / Output
+# @param ~id Force the value of the source ID.
+# @param ~fallible Allow the child source to fail, in which case the output will be (temporarily) stopped.
+# @param ~start Automatically start outputting whenever possible. If `true`, an infallible (normal) output will start outputting as soon as it is created, and a fallible output will (re)start as soon as its source becomes available for streaming.
+# @param s Source to play.
+def output.audio_video(~id=null, ~fallible=true, ~start=true, s) =
+  let {audio, video} = source.tracks(s)
+  output(id=id, fallible=fallible, start=start, source({audio = audio}))
+
+  output.video(id=id, fallible=fallible, start=start, source({video = video}))
+end
+
+def replaces input(~id=null, ~start=true, ~fallible=false) =
+  ignore(start)
+  ignore(fallible)
+  blank(id=id)
+end
+
+%ifdef input.alsa
+let replaces input = input.alsa
+%endif
+
+%ifdef input.oss
+let replaces input = input.oss
+%endif
+
+%ifdef input.portaudio
+let replaces input = input.portaudio
+%endif
+
+%ifdef input.pulseaudio
+let replaces input = input.pulseaudio
+%endif
+
+# Input an audio stream using the default operator.
+# @category Source / Input / Active
+# @param ~id Force the value of the source ID.
+# @param ~fallible Allow the child source to fail, in which case the output will be (temporarily) stopped.
+# @param ~start Automatically start outputting whenever possible. If `true`, an infallible (normal) output will start outputting as soon as it is created, and a fallible output will (re)start as soon as its source becomes available for streaming.
+def replaces input(~id=null, ~start=true, ~fallible=false) =
+  input(id=id, start=start, fallible=fallible)
+end

--- a/tests/liq/liquidsoap.liq
+++ b/tests/liq/liquidsoap.liq
@@ -1,0 +1,31 @@
+let liquidsoap.chroot = ()
+
+# Export all the files required to install liquidsoap in a root folder. Useful
+# for packaging and docker images.
+# @category Liquidsoap
+def liquidsoap.chroot.make(chroot) =
+  def chroot(p) =
+    path.concat(chroot, p)
+  end
+
+  def mkdir(p) =
+    process.run(
+      "mkdir -p #{process.quote(p)}"
+    )
+  end
+
+  def cp(source) =
+    mkdir(chroot(path.dirname(source)))
+    process.run(
+      "cp -rf #{process.quote(source)} #{process.quote(chroot(source))}"
+    )
+  end
+
+  cp(configure.libdir)
+  cp(configure.bindir)
+  if file.exists(settings.default_font()) then cp(settings.default_font()) end
+  mkdir(chroot(configure.logdir))
+  mkdir(chroot(configure.rundir))
+  cp(liquidsoap.executable)
+  ()
+end

--- a/tests/liq/list.liq
+++ b/tests/liq/list.liq
@@ -1,0 +1,440 @@
+# Add an element at the top of a list.
+# @category List
+def list.cons(x, l) =
+  list.add(x, l)
+end
+
+# "Delayed" version of `list.case` where the value on empty list is only
+# evaluated if necessary.
+# @category List
+def list.dcase(l, d, f) =
+  f = list.case(l, d, fun (x, l) -> {f(x, l)})
+  f()
+end
+
+# Return the head (first element) of a list, or `default` if the list is empty.
+# @category List
+# @param ~default Default value if key does not exist.
+def list.hd(~default=null, l) =
+  list.dcase(
+    l,
+    {
+      default
+        ?? error.raise(
+          error.not_found,
+          "no default value for list.hd"
+        )
+    },
+    fun (x, _) -> x
+  )
+end
+
+# Return the list without its first element.
+# @category List
+def list.tl(l) =
+  list.case(l, [], fun (_, l) -> l)
+end
+
+# Create a list with given length, filled with given element.
+# @category List
+# @param n Number of elements in the list.
+# @param x Element to fill the list with.
+def list.make(n, x) =
+  list.init(n, fun (_) -> x)
+end
+
+# Determining whether a list is empty or not.
+# @category List
+def list.is_empty(l) =
+  list.case(l, true, fun (_, _) -> false)
+end
+
+# Return the last element of a list.
+# @category List
+def list.last(~default=null, l) =
+  list.nth(default=default, l, list.length(l) - 1)
+end
+
+# Call a function on every element of a list.
+# @category List
+def list.iter(f, l) =
+  list.iteri(fun (_, v) -> f(v), l)
+end
+
+# Check whether an element belongs to a list.
+# @category List
+def list.mem(x, l) =
+  err = error.register("mem")
+  try
+    list.iter(fun (v) -> if v == x then error.raise(err, "found") end, l)
+    false
+  catch _ : [err] do
+    true
+  end
+end
+
+# Map a function on every element of a list, starting from the right. This
+# function is tail-recursive.
+# @category List
+def list.map.right(f, l) =
+  list.ind(l, [], fun (x, _, l) -> list.cons(f(x), l))
+end
+
+# Map a function on every element of a list, along with its index.
+# @category List
+def list.mapi(f, l) =
+  n = ref(0)
+
+  def f(x) =
+    i = n()
+    n := i + 1
+    f(i, x)
+  end
+
+  list.map(f, l)
+end
+
+# Add indices to every element of a list, so that it can be accessed with the
+# notation `l[n]`.
+# @category List
+def list.indexed(l) =
+  list.mapi(fun (i, x) -> (i, x), l)
+end
+
+# Fold a function on every element of a list: `list.fold(f,x1,[e1,..,en]) is f(...f(f(x1,e1),e2)...,en)`.
+# @category List
+# @param f Function `f` for which `f(x,e)` which will be called on every element `e` with the current value of `x`, returning the new value of `x`.
+# @param x Initial value x1, to be updated by successive calls of `f(x,e)`.
+def list.fold(f, x, l) =
+  ret = ref(x)
+  list.iter(fun (v) -> ret := f(ret(), v), l)
+  ret()
+end
+
+# Fold a function on every element of a list. Similar to `list.fold` but
+# iterates from the right of the list. It is slightly more efficient than
+# `list.fold`.
+# @category List
+# @param f Function `f` for which `f(x,e)` which will be called on every element `e` with the current value of `x`, returning the new value of `x`.
+# @param x Initial value x1, to be updated by successive calls of `f(x,e)`.
+def list.fold.right(f, x, l) =
+  list.ind(l, x, fun (e, _, r) -> f(e, r))
+end
+
+# Concatenate all the elements of a list of lists.
+# @category List
+def list.flatten(l) =
+  list.fold(fun (l, s) -> list.append(l, s), [], l)
+end
+
+# Filter a list according to a predicate. The order in which elements are
+# handled is not specified (and is currently implemented from the right).
+# @category List
+# @param ~remove Function called on an element when it is removed.
+# @param p Predicate indicating whether an element should be kept or not.
+# @param l List to filter.
+def list.filter(~remove=fun (_) -> (), p, l) =
+  # list.case(l, [], fun (x, l) -> if p(x) then list.cons(x, list.filter(p, l)) else list.filter(p, l) end)
+  list.ind(
+    l,
+    [],
+    fun (x, _, l) ->
+      if
+        p(x)
+      then
+        list.cons(x, l)
+      else
+        (remove(x) : unit)
+        l
+      end
+  )
+end
+
+# Map a function on a list (like `list.map`) excepting that the value is removed
+# if the function returns `null`.
+# @category List
+# @param f Function called on every element of the list.
+# @param l The list.
+def list.filter_map(f, l) =
+  def f(x, _, l) =
+    y = f(x)
+    if null.defined(y) then list.cons(null.get(y), l) else l end
+  end
+
+  list.ind(l, [], f)
+end
+
+# Associate a value to a key in an association list. This functions raises
+# `error.not_found` if no default value is specified.
+# @category List
+# @param ~default Value returned if the key is not found.
+def list.assoc(~default=null, key, l) =
+  ret = ref(💣())
+  err = error.register("assoc")
+  try
+    list.iter(
+      fun (v) ->
+        if
+          fst(v) == key
+        then
+          ret := snd(v)
+          error.raise(err, "found")
+        end,
+      l
+    )
+
+    null.case(
+      default,
+      fun () ->
+        error.raise(
+          error.not_found,
+          "no default value for list.assoc"
+        ),
+      fun (v) -> v
+    )
+  catch _ : [err] do
+    ret()
+  end
+end
+
+# `list.assoc.mem(key,l)` returns `true` if `l` contains a pair (key,value).
+# @category List
+# @param a Key to look for.
+# @param l List of pairs (key,value).
+def list.assoc.mem(a, l) =
+  err = error.register("find")
+  try
+    list.iter(fun (el) -> if fst(el) == a then error.raise(err, "found") end, l)
+    false
+  catch _ : [err] do
+    true
+  end
+end
+
+# Associate a value to a key in an association list. This functions is similar
+# to `list.assoc` excepting that it returns `null` if no value exists for the
+# key.
+# @category List
+def list.assoc.nullable(key, l) =
+  try
+    null(list.assoc(key, l))
+  catch _ do
+    null
+  end
+end
+
+# Keep only the elements of an association list satisfying a given predicate.
+# @category List
+def list.assoc.filter(p, l) =
+  def p(kv) =
+    p(fst(kv), snd(kv))
+  end
+
+  list.filter(p, l)
+end
+
+# Map a function of every element of the associative list, removing the entry if
+# the function returns `null`.
+# @category List
+def list.assoc.filter_map(f, l) =
+  def f(kv) =
+    f(fst(kv), snd(kv))
+  end
+
+  list.filter_map(f, l)
+end
+
+# Remove the first pair from an associative list.
+# @category List
+# @param key Key of pair to be removed.
+# @param l List of pairs (key,value).
+def list.assoc.remove(key, l) =
+  ret = ref(💣())
+  err = error.register("assoc.remove")
+  try
+    list.iter(
+      fun (v) ->
+        if
+          fst(v) == key
+        then
+          ret := snd(v)
+          error.raise(err, "found")
+        end,
+      l
+    )
+
+    l
+  catch _ : [err] do
+    list.remove((key, ret()), l)
+  end
+end
+
+# Remove all pairs with given key from an associative list.
+# @category List
+# @param key Key of pairs to be removed.
+# @param l List of pairs (key,value).
+def list.assoc.remove.all(key, l) =
+  list.assoc.filter(fun (k, _) -> k != key, l)
+end
+
+# Check that a predicate is satisfied for every element in a list.
+# @category List
+# @param p Predicate.
+# @param l List
+def list.for_all(p, l) =
+  err = error.register("for_all")
+  try
+    list.iter(fun (v) -> if not p(v) then error.raise(err, "found") end, l)
+    true
+  catch _ : [err] do
+    false
+  end
+end
+
+# Check that a predicate is satisfied for some element in a list.
+# @category List
+# @param p Predicate.
+# @param l List
+def list.exists(p, l) =
+  err = error.register("exists")
+  try
+    list.iter(fun (v) -> if p(v) then error.raise(err, "found") end, l)
+    false
+  catch _ : [err] do
+    true
+  end
+end
+
+# First element satisfying a predicate. Raises `error.not_found` if not element
+# is found and no default value was specified.
+# @category List
+# @param ~default Returned value when the predicate is not found.
+# @param p Predicate.
+# @param l List
+def list.find(~default=null, p, l) =
+  ret = ref(💣())
+  err = error.register("find")
+  try
+    list.iter(
+      fun (v) ->
+        if
+          p(v)
+        then
+          ret := v
+          error.raise(err, "found")
+        end,
+      l
+    )
+
+    null.case(
+      default,
+      fun () ->
+        error.raise(
+          error.not_found,
+          "no default value for list.find"
+        ),
+      fun (v) -> v
+    )
+  catch _ : [err] do
+    ret()
+  end
+end
+
+# First index where a predicate is satisfied.
+# @category List
+# @param p Predicate.
+# @param l List
+def list.index(p, l) =
+  list.ind(l, 0, fun (x, _, r) -> if p(x) then 0 else r + 1 end)
+end
+
+# Create an iterator over the elements of a list.
+# @category List
+def list.iterator(l) =
+  l = ref(l)
+
+  def f() =
+    list.case(
+      l(),
+      null,
+      fun (x, t) ->
+        begin
+          l := t
+          x
+        end
+    )
+  end
+
+  f
+end
+
+# Returns a copy of the given list with a new element inserted at a given
+# position. Raises `error.not_found` if the list has less than `index` elements.
+# @category List
+# @param index Index to insert at, starting at `0`.
+# @param new_element Element to insert
+# @param l List to insert into.
+def list.insert(index, new_element, l) =
+  if
+    list.length(l) < index
+  then
+    error.raise(
+      error.not_found,
+      "List should have at least #{index} elemments"
+    )
+  end
+
+  if
+    index == 0
+  then
+    new_element::l
+  else
+    def f(cur, el) =
+      let (pos, l) = cur
+      l = if pos + 1 == index then new_element::el::l else el::l end
+      (pos + 1, l)
+    end
+
+    let (_, l) = list.fold(f, (0, []), l)
+    list.rev(l)
+  end
+end
+
+# Compute the beginning of a list.
+# @category List
+# @param n Number of elements in the returned list.
+# @param l List whose prefix should be taken.
+def list.prefix(n, l) =
+  len = list.length(l)
+  n = n < len ? n : len
+  list.init(n, fun (n) -> list.nth(l, n))
+end
+
+# Pick a random element in a list.
+# @category List
+# @param ~default Value returned if the list is empty.
+# @param l List in which the element should be picked.
+def list.pick(~default=null, l) =
+  if
+    list.is_empty(l)
+  then
+    default
+      ?? error.raise(
+        error.not_found,
+        "empty list in list.pick"
+      )
+  else
+    list.nth(l, random.int(min=0, max=list.length(l)))
+  end
+end
+
+# Sort a list according to the "natural" order.
+# @category List
+# @param l List to sort
+def list.sort.natural(l) =
+  def compare(x, y) =
+    if x < y then -1 elsif x > y then 1 else 0 end
+  end
+
+  list.sort(compare, l)
+end

--- a/tests/liq/log.liq
+++ b/tests/liq/log.liq
@@ -1,0 +1,47 @@
+# Log a critical message
+# @category Liquidsoap
+def log.critical(~label="lang", msg) =
+  log(label=label, level=1, msg)
+end
+
+# Log a severe message
+# @category Liquidsoap
+def log.severe(~label="lang", msg) =
+  log(label=label, level=2, msg)
+end
+
+# Log an important message
+# @category Liquidsoap
+def log.important(~label="lang", msg) =
+  log(label=label, level=3, msg)
+end
+
+# Log a normal message
+# @category Liquidsoap
+def log.info(~label="lang", msg) =
+  log(label=label, level=4, msg)
+end
+
+# Log a debug message
+# @category Liquidsoap
+def log.debug(~label="lang", msg) =
+  log(label=label, level=5, msg)
+end
+
+# Get and set the log level.
+# @category Liquidsoap
+def log.level =
+  settings.log.level
+end
+
+# Get and set the file logging
+# @category Liquidsoap
+def log.file =
+  settings.log.file
+end
+
+# Get and set logging to stdout
+# @category Liquidsoap
+def log.stdout =
+  settings.log.stdout
+end

--- a/tests/liq/lufs.liq
+++ b/tests/liq/lufs.liq
@@ -1,0 +1,295 @@
+let settings.lufs = ()
+
+let settings.lufs.track_gain_target =
+  settings.make(
+    description="Target LUFS All available autocue implementations",
+    -16.
+  )
+
+let settings.lufs.integrated_metadata =
+  settings.make(
+    description="Metadata used to store integrated LUFS",
+    "liq_integrated_lufs"
+  )
+
+let settings.lufs.decoding_ratio =
+  settings.make(
+    description="Decoding ratio used when decoding integrated LUFS from files",
+    50.
+  )
+
+let settings.lufs.true_peak_max =
+  settings.make(
+    description="Maximum allowed true peak (dBTP) after LUFS normalization. \
+     Tracks whose true peak would exceed this after gain application will have \
+     their gain reduced accordingly. EBU R128 mandates -1.0 dBTP.",
+    -1.0
+  )
+
+let file.lufs = ()
+
+# Compute the LUFS of a file (in dB).
+# @category File
+# @param ~id Force the value of the source ID.
+# @param ~ratio Decoding ratio. A value of `50` means try to decode the file `50x` faster than real time, if possible. Use this setting to lower CPU peaks when computing lufs tags. Defaults to `settings.lufs.decoding_ratio` when `null`
+# @param file_name File name.
+# @flag hidden
+def file.lufs.compute(~ratio=null, file_name) =
+  ratio = ratio ?? settings.lufs.decoding_ratio()
+  _request = request.create(resolve_metadata=false, file_name)
+  if
+    request.resolve(_request)
+  then
+    get_lufs = ref(fun () -> null)
+    def process(s) =
+      s = lufs(s)
+      get_lufs := {s.lufs_integrated()}
+      s
+    end
+
+    request.process(ratio=ratio, process=process, _request)
+
+    fn = get_lufs()
+    fn()
+  else
+    null
+  end
+end
+
+# Compute the integrated LUFS and true peak of a file in a single decoding pass.
+# Returns a record `{lufs, true_peak}` (both in dB / dBTP), or `null` on failure.
+# @category File
+# @param ~ratio Decoding ratio. Defaults to `settings.lufs.decoding_ratio` when `null`.
+# @param file_name File name.
+# @flag hidden
+def file.lufs.compute_with_peak(~ratio=null, file_name) =
+  ratio = ratio ?? settings.lufs.decoding_ratio()
+  _request = request.create(resolve_metadata=false, file_name)
+  if
+    request.resolve(_request)
+  then
+    get_lufs = ref(fun () -> null)
+    get_tp = ref(fun () -> null)
+    def process(s) =
+      s = lufs(s)
+      get_lufs := {s.lufs_integrated()}
+      get_tp := {s.true_peak()}
+      s
+    end
+    request.process(ratio=ratio, process=process, _request)
+    lufs_fn = get_lufs()
+    tp_fn = get_tp()
+    lufs_val = lufs_fn()
+    tp_val = tp_fn()
+    if
+      null.defined(lufs_val) and null.defined(tp_val)
+    then
+      {lufs = null.get(lufs_val), true_peak = null.get(tp_val)}
+    else
+      null
+    end
+  else
+    null
+  end
+end
+
+# Extract the LUFS from the metadata (in dB).
+# @category Metadata
+# @param _metadata Metadata from which the LUFS should be extracted.
+def metadata.lufs(_metadata) =
+  k = settings.lufs.integrated_metadata()
+  if
+    list.assoc.mem(k, _metadata)
+  then
+    lufs_metadata = _metadata[k]
+    match = r/([+-]?\d*\.?\d*)/.exec(lufs_metadata)
+    try
+      float_of_string(list.assoc(1, match))
+    catch _ do
+      null
+    end
+  else
+    null
+  end
+end
+
+# Get the LUFS for a file (in dB).
+# @category File
+# @param ~id Force the value of the source ID.
+# @param ~compute Compute LUFS if metadata tag is empty.
+# @param ~ratio Decoding ratio. A value of `50` means try to decode the file `50x` faster than real time, if possible. Use this setting to lower CPU peaks when computing lufs tags. Defaults to `settings.lufs.decoding_ratio` when `null`.
+# @param file_name File name.
+def replaces file.lufs(~id=null, ~compute=true, ~ratio=null, file_name) =
+  id = string.id.default(default="file.lufs", id)
+  file_name_quoted = string.quote(file_name)
+  ratio = ratio ?? settings.lufs.decoding_ratio()
+
+  _metadata = file.metadata(exclude=decoder.metadata.reentrant(), file_name)
+  gain = metadata.lufs(_metadata)
+
+  if
+    gain != null
+  then
+    log.info(
+      label=id,
+      "Detected track lufs #{gain} dB for #{file_name_quoted}."
+    )
+    gain
+  elsif
+    compute
+  then
+    log.info(
+      label=id,
+      "Computing integrated LUFS for #{file_name_quoted}."
+    )
+    start_time = time()
+    gain = file.lufs.compute(ratio=ratio, file_name)
+    elapsed_time = time() - start_time
+    if
+      gain != null
+    then
+      log.info(
+        label=id,
+        "Computed integrated LUFS of #{gain} dB for #{file_name_quoted} (time: #{
+          elapsed_time
+        } s)."
+      )
+    end
+    gain
+  else
+    null
+  end
+end
+
+# Enable LUFS metadata resolver. This resolver will process any file
+# decoded by Liquidsoap and add a `liq_normalize_track_gain` metadata when this
+# value could be computed (key is configurable via `settings.normalize_track_gain_metadata`).
+# For a finer-grained replay gain processing, use the `lufs_track_gain:` protocol.
+#
+# When `true_peak=true`, both integrated LUFS and true peak are measured
+# in a single pass. The gain written to `liq_normalize_track_gain` is then
+# adjusted so the true peak after amplification does not exceed
+# `settings.lufs.true_peak_max` (default -1.0 dBTP, per EBU R128):
+#
+#  - If true peak after LUFS gain <= tp_max: gain is used as-is.
+#  - If true peak after LUFS gain is in (tp_max, tp_max+0.5]: gain is reduced
+#    by `tp_after_gain - tp_max` so that true peak lands exactly at tp_max.
+#    Maximum attenuation in this range is 0.5 dB.
+#  - If true peak after LUFS gain > tp_max+0.5: same correction is applied, but
+#    a warning is logged. A dynamic limiter may be needed for these tracks.
+#
+# When `true_peak=false` (default), only integrated LUFS is measured and the
+# gain is set purely from LUFS — no true peak correction is applied. This
+# preserves the original behaviour.
+#
+# When `compute=false`, the existing LUFS metadata is used without any
+# computation (same behaviour as before).
+#
+# @param ~compute Compute LUFS if metadata tag is empty.
+# @param ~true_peak Also measure true peak and apply EBU R128 TP correction to the gain.
+# @param ~ratio Decoding ratio. A value of `50.` means try to decode the file `50x` faster than real time, if possible. Defaults to `settings.lufs.decoding_ratio` when `null`.
+# @category Liquidsoap
+def enable_lufs_track_gain_metadata(
+  ~compute=true,
+  ~true_peak=true,
+  ~ratio=null
+) =
+  ratio = ratio ?? settings.lufs.decoding_ratio()
+  def lufs_metadata(~metadata:_, file_name) =
+    if
+      compute and true_peak
+    then
+      # Single-pass scan: measure both LUFS and true peak, apply TP correction.
+      result = file.lufs.compute_with_peak(ratio=ratio, file_name)
+      if
+        result != null
+      then
+        let {lufs = measured_lufs, true_peak = measured_tp} = null.get(result)
+        target = settings.lufs.track_gain_target()
+        tp_max = settings.lufs.true_peak_max()
+        gain_lufs = target - measured_lufs
+        tp_after = measured_tp + gain_lufs
+
+        # x is the correction: negative (attenuation) when tp_after > tp_max.
+        x = tp_max - tp_after
+
+        final_gain =
+          if
+            tp_after <= tp_max
+          then
+            # Case 1: true peak within limit, LUFS target is met exactly.
+            gain_lufs
+          elsif
+            tp_after <= tp_max + 0.5
+          then
+            # Case 2: mild overshoot (up to 0.5 dB), correct by reducing gain.
+            # Resulting LUFS-I will be slightly below target (max 0.5 LU deviation),
+            # but within allowed variance of ± 1 dB.
+            gain_lufs + x
+          else
+            # Case 3: overshoot exceeds 0.5 dB. Capping gain reduction at 0.5 dB
+            # to keep LUFS-I no lower than target - 0.5 LU (EBU R128 floor).
+            # Remaining TP excess must be handled by a limiter.
+            log.important(
+              label="lufs",
+              "#{string.quote(file_name)}: true peak after normalization would \
+               be #{tp_after} dBTP (#{tp_after - tp_max} dB over limit). Gain \
+               correction capped at 0.5 dB to preserve LUFS-I; a limiter is \
+               required for this track."
+            )
+            gain_lufs - 0.5
+          end
+
+        [
+          (
+            settings.normalize_track_gain_metadata(),
+            "#{final_gain} dB"
+          ),
+          (
+            settings.lufs.integrated_metadata(),
+            "#{measured_lufs} LUFS"
+          ),
+          ("lufs_true_peak", "#{measured_tp}")
+        ]
+      else
+        []
+      end
+    elsif
+      compute
+    then
+      # LUFS-only scan: no true peak measurement or correction (default behaviour).
+      # Uses file.lufs() which checks for existing metadata before computing,
+      # matching the original behaviour exactly.
+      gain = file.lufs(compute=true, ratio=ratio, file_name)
+      if
+        gain != null
+      then
+        [
+          (
+            settings.normalize_track_gain_metadata(),
+            "#{settings.lufs.track_gain_target() - null.get(gain)} dB"
+          )
+        ]
+      else
+        []
+      end
+    else
+      # compute=false: use existing LUFS metadata, no computation at all.
+      gain = file.lufs(compute=false, ratio=ratio, file_name)
+      if
+        gain != null
+      then
+        [
+          (
+            settings.normalize_track_gain_metadata(),
+            "#{settings.lufs.track_gain_target() - null.get(gain)} dB"
+          )
+        ]
+      else
+        []
+      end
+    end
+  end
+
+  decoder.metadata.add(reentrant=true, "lufs_track_gain", lufs_metadata)
+end

--- a/tests/liq/math.liq
+++ b/tests/liq/math.liq
@@ -1,0 +1,23 @@
+# Compute the minimum of two values.
+# @category Math
+def min(a, b) =
+  if a <= b then a else b end
+end
+
+# Compute the maximum of two values.
+# @category Math
+def max(a, b) =
+  if a >= b then a else b end
+end
+
+# Convert linear scale into decibels.
+# @category Math
+def dB_of_lin(x) =
+  20. * log10(x)
+end
+
+# Convert decibels into linear scale.
+# @category Math
+def lin_of_dB(x) =
+  pow(10., x / 20.)
+end

--- a/tests/liq/medialib.liq
+++ b/tests/liq/medialib.liq
@@ -1,0 +1,752 @@
+# A library to store the metadata of files in given folders and query them. This
+# is useful to generate playlists based on metadata.
+# @category File
+# @param ~persistency Store the database in given file, which is reuse to populate the database on next run.
+# @param ~refresh Scan directories for new files every given number of seconds (by default the database is never updated).
+# @param ~standardize Function mapped on metadata when indexing. It can be used to change the field names to standard ones, pretreat data, etc.
+# @param ~initial_progress Show progress of library being indexed at startup.
+# @param ~directories Directories to look for files in.
+# @param dir Directory to look for files in.
+# @method find Find files according to conditions on metadata.
+# @method refresh Update metadatas and look for new files.
+# @method add_directory Add a new directory which should be scanned.
+# @method clear Remove all known metadata.
+def medialib(
+  ~id=null,
+  ~persistency=null,
+  ~refresh=null,
+  ~standardize=fun (m) -> m,
+  ~initial_progress=true,
+  ~directories=[],
+  dir=null
+) =
+  id = string.id.default(default="medialib", id)
+  refresh_time = refresh
+  directories = ref(directories)
+  if null.defined(dir) then directories := null.get(dir)::directories() end
+  db = ref([])
+
+  def dt(t) =
+    string.float(decimal_places=2, time() - t)
+  end
+
+  # Read metadata from file.
+  def metadata(f) =
+    m = file.metadata.native(f)
+    m = standardize(m)
+
+    # Sanitize
+    m = metadata.cover.remove(m)
+    m = list.assoc.filter(fun (k, _) -> not list.mem(k, ["priv", "rva2"]), m)
+
+    # Add more metadata
+    m = ("basename", path.basename(f))::m
+    m =
+      (
+        "last scan",
+        string.float(time())
+      )::m
+    m
+  end
+
+  # Whether an entry needs to be updated.
+  def needs_update(f, m) =
+    file.mtime(f) >
+      string.to_float(
+        m[
+          "last scan"
+        ]
+      )
+  end
+
+  # Add a file to the database.
+  def add(f) =
+    # If file doesn't exist remove it
+    if
+      not (file.exists(f))
+    then
+      db := list.assoc.remove(f, db())
+    else
+      # New file or not recent enough metadata
+      if
+        not list.assoc.mem(f, db()) or needs_update(f, list.assoc(f, db()))
+      then
+        db := (f, metadata(f))::list.assoc.remove(f, db())
+      end
+    end
+  end
+
+  # Update database by renewing metadata and removing removed files.
+  def update(~progress=fun (_, _) -> ()) =
+    len = list.length(db())
+    n = ref(0)
+    nu = ref(0)
+
+    def u(fm) =
+      let (f, m) = fm
+      ref.incr(n)
+      progress(n(), len)
+      if
+        not (file.exists(f))
+      then
+        null
+      elsif
+        needs_update(f, m)
+      then
+        ref.incr(nu)
+        (f, metadata(f))
+      else
+        (f, m)
+      end
+    end
+
+    db := list.filter_map(u, db())
+    log.debug(
+      label=id,
+      "Updated #{nu()} files."
+    )
+  end
+
+  # Make sure that new files from directories are registered.
+  def scan(~progress=fun (_, _) -> ()) =
+    l =
+      list.map(
+        fun (d) -> file.ls(absolute=true, recursive=true, d),
+        directories()
+      )
+
+    l = list.flatten(l)
+    n = ref(0)
+    len = list.length(l)
+
+    def add(f) =
+      ref.incr(n)
+      progress(n(), len)
+      add(f)
+    end
+
+    list.iter(add, l)
+  end
+
+  # Increment when the format of the db changes
+  db_version = 1
+
+  # Load from the persistent file.
+  def load() =
+    db := []
+    if
+      null.defined(persistency)
+    then
+      f = null.get(persistency)
+      if
+        file.exists(f)
+      then
+        try
+          let json.parse ((v, parsed) :
+            (int * [(string * [(string * string)])]?)
+          ) = file.contents(f)
+
+          if
+            v == db_version and null.defined(parsed)
+          then
+            db := null.get(parsed)
+          end
+        catch e do
+          log.important(
+            label=id,
+            "Failed to parse persistent file #{f}: #{e.kind}: #{e.message}"
+          )
+        end
+      end
+    end
+  end
+
+  # Store the file in a persistent file.
+  def store() =
+    if
+      null.defined(persistency)
+    then
+      f = null.get(persistency)
+      data = json.stringify(compact=true, (db_version, db()))
+      file.write(data=data, f)
+      log.info(
+        label=id,
+        "Wrote persistent file #{f}"
+      )
+    end
+  end
+
+  # Refresh the library.
+  def refresh() =
+    log.info(
+      label=id,
+      "Refreshing the library..."
+    )
+    t = time()
+    update()
+    scan()
+    store()
+    log.info(
+      label=id,
+      "Refreshed the library in #{dt(t)}s."
+    )
+  end
+
+  # Find all files matching given criteria.
+  def find(
+    ~case_sensitive=true,
+    ~artist=null,
+    ~artist_contains=null,
+    ~artist_matches=null,
+    ~album=null,
+    ~genre=null,
+    ~title=null,
+    ~title_contains=null,
+    ~filename=null,
+    ~filename_contains=null,
+    ~filename_matches=null,
+    ~year=null,
+    ~year_ge=null,
+    ~year_lt=null,
+    ~bpm=null,
+    ~bpm_ge=null,
+    ~bpm_lt=null,
+    ~predicate=(fun (_) -> true)
+  ) =
+    def p(m) =
+      def eq(s, t) =
+        if case_sensitive then s == t else string.case(s) == string.case(t) end
+      end
+
+      def contains(s, t) =
+        if
+          case_sensitive
+        then
+          string.contains(substring=s, t)
+        else
+          string.contains(substring=string.case(s), string.case(t))
+        end
+      end
+
+      def eqf(k, v) =
+        null.defined(v) ? eq(m[k], null.get(v)) : true
+      end
+
+      def ctf(k, v) =
+        null.defined(v) ? contains(null.get(v), m[k]) : true
+      end
+
+      def mtf(k, v) =
+        null.defined(v) ? string.match(pattern=null.get(v), m[k]) : true
+      end
+
+      eqf("artist", artist)
+      and ctf("artist", artist_contains)
+      and mtf("artist", artist_matches)
+      and eqf("album", album)
+      and eqf("genre", genre)
+      and eqf("title", title)
+      and ctf("title", title_contains)
+      and eqf("filename", filename)
+      and ctf("basename", filename_contains)
+      and mtf("basename", filename_matches)
+      and if
+        null.defined(year) or null.defined(year_ge) or null.defined(year_lt)
+      then
+        if
+          string.is_int(m["year"])
+        then
+          y = string.to_int(m["year"])
+          (null.defined(year) ? y == null.get(year) : true)
+          and (null.defined(year_ge) ? y >= null.get(year_ge) : true)
+          and (null.defined(year_lt) ? y < null.get(year_lt) : true)
+        else
+          false
+        end
+      else
+        true
+      end
+      and if
+        null.defined(bpm) or null.defined(bpm_ge) or null.defined(bpm_lt)
+      then
+        if
+          string.is_int(m["bpm"])
+        then
+          b = string.to_int(m["bpm"])
+          (null.defined(bpm) ? b == null.get(bpm) : true)
+          and (null.defined(bpm_ge) ? b >= null.get(bpm_ge) : true)
+          and (null.defined(bpm_lt) ? b < null.get(bpm_lt) : true)
+        else
+          false
+        end
+      else
+        true
+      end
+      and predicate(m)
+    end
+
+    l = list.filter(fun (fm) -> p(snd(fm)), db())
+    l = list.map(fst, l)
+    l
+  end
+
+  t = time()
+  load()
+  log.important(
+    label=id,
+    "Loaded library from #{persistency} in #{dt(t)}s: #{list.length(db())} \
+     entries"
+  )
+
+  t = time()
+  progress =
+    if
+      initial_progress
+    then
+      fun (n, l) ->
+        print(
+          newline=false,
+          "#{id}: updating #{n * 100 / l}%...\r"
+        )
+    else
+      fun (_, _) -> ()
+    end
+
+  update(progress=progress)
+  log.important(
+    label=id,
+    "Updated library in #{dt(t)}s: #{list.length(db())} entries"
+  )
+
+  t = time()
+  progress =
+    if
+      initial_progress
+    then
+      fun (n, l) ->
+        print(
+          newline=false,
+          "#{id}: scanning #{n * 100 / l}%...\r"
+        )
+    else
+      fun (_, _) -> ()
+    end
+
+  scan(progress=progress)
+  log.important(
+    label=id,
+    "Scanned new files in #{dt(t)}s: #{list.length(db())} entries"
+  )
+
+  store()
+  log.important(
+    label=id,
+    "Stored library"
+  )
+  if
+    null.defined(refresh_time)
+  then
+    thread.run(
+      delay=null.get(refresh_time),
+      every=null.get(refresh_time),
+      refresh
+    )
+  end
+
+  def clear() =
+    db := []
+  end
+
+  def add_directory(d) =
+    directories := d::directories()
+    scan()
+  end
+
+  {find = find, refresh = refresh, add_directory = add_directory, clear = clear}
+end
+
+%ifdef sqlite
+# A library to store the metadata of files in given folders and query
+# them. This is useful to generate playlists based on metadata. This version
+# use an SQL implementation which should be much faster and less memory
+# consuming than the basic one.
+# @category File
+# @param ~persistency Store the database in given file, which is reuse to populate the database on next run.
+# @param ~refresh Scan directories for new files every given number of seconds (by default the database is never updated).
+# @param ~standardize Function mapped on metadata when indexing. It can be used to change the field names to standard ones, pretreat data, etc.
+# @param ~initial_progress Show progress of library being indexed at startup.
+# @param ~directories Directories to look for files in.
+# @param dir Directory to look for files in.
+# @method find Find files according to conditions on metadata.
+# @method refresh Update metadatas and look for new files.
+# @method add_directory Add a new directory which should be scanned.
+# @method clear Remove all known metadata.
+def medialib.sqlite(
+  ~id=null,
+  ~database,
+  ~refresh=null,
+  ~standardize=fun (m) -> m,
+  ~initial_progress=true,
+  ~directories=[],
+  dir=null
+) =
+  id = string.id.default(default="medialib.sqlite", id)
+  refresh_time = refresh
+  directories = ref(directories)
+  if null.defined(dir) then directories := null.get(dir)::directories() end
+
+  fields_string = ["artist", "title", "album", "genre", "basename"]
+  fields_int = ["year", "bpm"]
+  fields_float = ["last_scan"]
+
+  db = sqlite(database)
+  begin
+    fields_string = list.map(fun (l) -> (l, "STRING"), fields_string)
+    fields_int = list.map(fun (l) -> (l, "INT"), fields_int)
+    fields_float = list.map(fun (l) -> (l, "FLOAT"), fields_float)
+    db.table.create(
+      "metadata",
+      preserve=true,
+      [
+        (
+          "file",
+          "STRING PRIMARY KEY"
+        ),
+        ...fields_string,
+        ...fields_int,
+        ...fields_float
+      ]
+    )
+  end
+
+  def dt(t) =
+    string.float(decimal_places=2, time() - t)
+  end
+
+  # Read metadata from file.
+  def metadata(f) =
+    m = file.metadata.native(f)
+    m = standardize(m)
+
+    # Sanitize
+    m = metadata.cover.remove(m)
+    m = list.assoc.filter(fun (k, _) -> not list.mem(k, ["priv", "rva2"]), m)
+
+    # Add more metadata
+    m = ("basename", path.basename(f))::m
+    m = ("last_scan", string.float(time()))::m
+    m
+  end
+
+  # Whether an entry needs to be updated.
+  def needs_update(f, last_scan) =
+    file.mtime(f) > last_scan
+  end
+
+  # Remove file from the database
+  def remove(f) =
+    db.delete(table="metadata", where="file=#{sqlite.escape(f)}")
+  end
+
+  # Add a file to the database.
+  def add(f) =
+    # If file doesn't exist remove it
+    if
+      not (file.exists(f))
+    then
+      remove(f)
+    else
+      count = db.count(table="metadata", where="file=#{sqlite.escape(f)}")
+      def last_scan() =
+        let sqlite.query ([{last_scan}] : [{last_scan: float}]) =
+          db.select(
+            "last_scan",
+            table="metadata",
+            where="file=#{sqlite.escape(f)}"
+          )
+        last_scan
+      end
+
+      # New file or not recent enough metadata
+      if
+        count == 0 or needs_update(f, last_scan())
+      then
+        m = metadata(f)
+        def field(~map, k) =
+          def map(x) =
+            # Harden
+            try
+              map(x)
+            catch _ do
+              null
+            end
+          end
+          if list.assoc.mem(k, m) then map(list.assoc(k, m)) else null end
+        end
+        id = fun (x) -> x
+        m =
+          {
+            file = f,
+            artist = field(map=id, "artist"),
+            title = field(map=id, "title"),
+            album = field(map=id, "album"),
+            genre = field(map=id, "genre"),
+            basename = field(map=id, "basename"),
+            last_scan = field(map=float_of_string, "last_scan"),
+            year = field(map=int_of_string, "year"),
+            bpm = field(map=int_of_string, "bpm")
+          }
+        db.insert(table="metadata", replace=true, m)
+      end
+    end
+  end
+
+  # Number of entries in the database
+  def count() =
+    db.count(table="metadata")
+  end
+
+  # Update database by renewing metadata and removing removed files.
+  def update(~progress=fun (_, _) -> ()) =
+    len = count()
+    n = ref(0)
+    nu = ref(0)
+
+    def u(row) =
+      ref.incr(n)
+      progress(n(), len)
+      let sqlite.row ({file} : {file: string}) = row
+      add(file)
+    end
+
+    db.select.iter(u, "file", table="metadata")
+    log.debug(
+      label=id,
+      "Updated #{nu()} files."
+    )
+  end
+
+  # Make sure that new files from directories are registered.
+  def scan(~progress=fun (_, _) -> ()) =
+    l =
+      list.map(
+        fun (d) -> file.ls(absolute=true, recursive=true, d),
+        directories()
+      )
+
+    l = list.flatten(l)
+    n = ref(0)
+    len = list.length(l)
+
+    def add(f) =
+      ref.incr(n)
+      progress(n(), len)
+      add(f)
+    end
+
+    list.iter(add, l)
+  end
+
+  # Refresh the library.
+  def refresh() =
+    log.info(
+      label=id,
+      "Refreshing the library..."
+    )
+    t = time()
+    update()
+    scan()
+    log.info(
+      label=id,
+      "Refreshed the library in #{dt(t)}s."
+    )
+  end
+
+  # Find all files matching given criteria.
+  def find(
+    ~case_sensitive=true,
+    ~artist=null,
+    ~artist_contains=null,
+    ~artist_matches=null,
+    ~album=null,
+    ~genre=null,
+    ~title=null,
+    ~title_contains=null,
+    ~filename=null,
+    ~filename_contains=null,
+    ~filename_matches=null,
+    ~year=null,
+    ~year_ge=null,
+    ~year_lt=null,
+    ~bpm=null,
+    ~bpm_ge=null,
+    ~bpm_lt=null,
+    ~condition=null
+  ) =
+    predicates = ref([])
+    def pred(p) =
+      predicates := p::predicates()
+    end
+    if null.defined(condition) then pred(null.get(condition)) end
+    def cmp(op, k, v) =
+      if
+        null.defined(v)
+      then
+        v = null.get(v)
+        p =
+          if
+            case_sensitive
+          then
+            (
+              "#{k} #{op} #{sqlite.escape(v)}"
+            )
+          else
+            (
+              "UPPER(#{k}) #{op} UPPER(#{sqlite.escape(v)})"
+            )
+          end
+        pred(p)
+      end
+    end
+    def eqf(k, v) =
+      cmp("=", k, v)
+    end
+    def ctf(k, v) =
+      if
+        null.defined(v)
+      then
+        v = null.get(v)
+        cmp("LIKE", k, "%" ^ v ^ "%")
+      end
+    end
+    def mtf(k, v) =
+      cmp("MATCHES", k, v)
+    end
+
+    eqf("artist", artist)
+    ctf("artist", artist_contains)
+    mtf("artist", artist_matches)
+    eqf("album", album)
+    eqf("genre", genre)
+    eqf("title", title)
+    ctf("title", title_contains)
+    eqf("filename", filename)
+    ctf("basename", filename_contains)
+    mtf("basename", filename_matches)
+    if
+      null.defined(year)
+    then
+      year = null.get(year)
+      pred("year=#{year}")
+    end
+    if
+      null.defined(year_ge)
+    then
+      year_ge = null.get(year_ge)
+      pred(
+        "year >= #{year_ge}"
+      )
+    end
+    if
+      null.defined(year_lt)
+    then
+      year_lt = null.get(year_lt)
+      pred(
+        "year < #{year_lt}"
+      )
+    end
+    if
+      null.defined(bpm)
+    then
+      bpm = null.get(bpm)
+      pred("bpm=#{bpm}")
+    end
+    if
+      null.defined(bpm_ge)
+    then
+      bpm_ge = null.get(bpm_ge)
+      pred(
+        "bpm >= #{bpm_ge}"
+      )
+    end
+    if
+      null.defined(bpm_lt)
+    then
+      bpm_lt = null.get(bpm_lt)
+      pred(
+        "bpm < #{bpm_lt}"
+      )
+    end
+    predicates =
+      string.concat(
+        separator=" AND ",
+        predicates()
+      )
+
+    let sqlite.query (l : [{file: string}]) =
+      db.select("file", table="metadata", where=predicates)
+    list.map((fun (l) -> l.file), l)
+  end
+
+  t = time()
+  progress =
+    if
+      initial_progress
+    then
+      fun (n, l) ->
+        print(
+          newline=false,
+          "#{id}: updating #{n * 100 / l}%...\r"
+        )
+    else
+      fun (_, _) -> ()
+    end
+
+  update(progress=progress)
+  log.important(
+    label=id,
+    "Updated library in #{dt(t)}s: #{count()} entries"
+  )
+
+  t = time()
+  progress =
+    if
+      initial_progress
+    then
+      fun (n, l) ->
+        print(
+          newline=false,
+          "#{id}: scanning #{n * 100 / l}%...\r"
+        )
+    else
+      fun (_, _) -> ()
+    end
+
+  scan(progress=progress)
+  log.important(
+    label=id,
+    "Scanned new files in #{dt(t)}s: #{count()} entries"
+  )
+
+  if
+    null.defined(refresh_time)
+  then
+    thread.run(
+      delay=null.get(refresh_time),
+      every=null.get(refresh_time),
+      refresh
+    )
+  end
+
+  def clear() =
+    db.delete(table="metadata")
+  end
+
+  def add_directory(d) =
+    directories := d::directories()
+    scan()
+  end
+
+  {find = find, refresh = refresh, add_directory = add_directory, clear = clear}
+end
+%endif

--- a/tests/liq/metadata.liq
+++ b/tests/liq/metadata.liq
@@ -1,0 +1,253 @@
+let metadata.getter = ()
+
+# Create a getter from a metadata.
+# @category Metadata
+# @flag hidden
+# @param init Initial value.
+# @param map Function to apply to the metadata value to obtain the new value.
+# @param metadata Metadata on which the value should be updated.
+# @param s Source containing the metadata.
+def metadata.getter.base(init, map, metadata, s) =
+  x = ref(init)
+
+  def f(m) =
+    v = m[metadata]
+    if v != "" then x := map(v) end
+  end
+
+  s.on_metadata(synchronous=true, f)
+  ref.getter(x)
+end
+
+let metadata.getter.source = ()
+
+# Variant of `metadata.getter.base` which also returns the source. Using this
+# variant is a bit more complex, but safer this it does not involve a global
+# state, which might unexpectedly change the metadata if a source is used at
+# various places.
+# @flag hidden
+def metadata.getter.source.base(init, map, metadata, s) =
+  x = ref(init)
+
+  def f(m) =
+    v = m[metadata]
+    if v != "" then x := map(v) end
+  end
+
+  s.on_metadata(synchronous=true, f)
+  (s, ref.getter(x))
+end
+
+# Create a getter from a metadata: this is a string, whose value can be changed
+# with a metadata.
+# @category Metadata
+# @param init Initial value.
+# @param m Metadata on which the value should be updated.
+# @param s Source containing the metadata.
+def replaces metadata.getter(init, m, s) =
+  metadata.getter.base(init, fun (v) -> v, m, s)
+end
+
+# Create a float getter from a metadata: this is a float, whose value can be
+# changed with a metadata.
+# @category Metadata
+# @param init Initial value.
+# @param m Metadata on which the value should be updated.
+# @param s Source containing the metadata.
+def metadata.getter.float(init, m, s) =
+  metadata.getter.base(init, float_of_string, m, s)
+end
+
+# Create a float getter from a metadata: this is a float, whose value can be
+# changed with a metadata. This function also returns the source.
+# @category Metadata
+# @param init Initial value.
+# @param m Metadata on which the value should be updated.
+# @param s Source containing the metadata.
+def metadata.getter.source.float(init, m, s) =
+  metadata.getter.source.base(init, float_of_string, m, s)
+end
+
+# Extract filename from metadata.
+# @category Metadata
+def metadata.filename(m) =
+  m["filename"]
+end
+
+# Extract title from metadata.
+# @category Metadata
+def metadata.title(m) =
+  m["title"]
+end
+
+# Extract artist from metadata.
+# @category Metadata
+def metadata.artist(m) =
+  m["artist"]
+end
+
+# Extract comment from metadata.
+# @category Metadata
+def metadata.comment(m) =
+  m["comment"]
+end
+
+# Extract cover from metadata. This function implements cover extraction
+# for the following formats: coverart (ogg), apic (flac, mp3) and pic (mp3).
+# @category Metadata
+# @param m Metadata from which the cover should be extracted.
+# @param ~coverart_mime Mime type to use for `"coverart"` metadata. Support disabled if `null`.
+# @method mime MIME type for the cover.
+def metadata.cover(~coverart_mime=null, m) =
+  fname = metadata.filename(m)
+  if
+    list.assoc.mem("coverart", m) and null.defined(coverart_mime)
+  then
+    cover = list.assoc(default="", "coverart", m)
+    string.base64.decode(cover).{mime = null.get(coverart_mime)}
+  elsif
+    list.assoc.mem("metadata_block_picture", m)
+  then
+    # See https://xiph.org/flac/format.html#metadata_block_picture
+    cover = list.assoc(default="", "metadata_block_picture", m)
+    cover = file.metadata.flac.cover.decode(cover)
+    if
+      not null.defined(cover)
+    then
+      log.info(
+        "Failed to read cover metadata for #{fname}."
+      )
+      null
+    else
+      null.get(cover)
+    end
+  else
+    # Assume we have an mp3 file
+    m =
+      if
+        list.assoc.mem("apic", m) or list.assoc.mem("pic", m)
+      then
+        m
+      else
+        # Try the builtin tag reader because APIC tags are not read by default,
+        log.debug(
+          label="metadata.cover",
+          "APIC or PIC not found for #{fname}, trying builtin tag reader."
+        )
+
+        file.metadata.id3v2(fname)
+      end
+
+    pic = list.assoc(default="", "pic", m)
+    apic = list.assoc(default="", "apic", m)
+    if
+      apic != ""
+    then
+      log.debug(
+        label="metadata.cover",
+        "Found APIC for #{fname}."
+      )
+
+      # TODO: we could use file type in order to select cover if there are many
+      string.apic.parse(apic)
+    elsif
+      pic != ""
+    then
+      log.debug(
+        label="metadata.cover",
+        "Found APIC for #{fname}."
+      )
+
+      # TODO: we could use file type in order to select cover if there are many
+      pic = string.pic.parse(pic)
+      mime =
+        if
+          pic.format == "JPG"
+        then
+          "image/jpeg"
+        elsif
+          pic.format == "PNG"
+        then
+          "image/png"
+        else
+          "application/octet-stream"
+        end
+
+      pic.{mime = mime}
+    else
+      log.info(
+        "No cover found for #{fname}."
+      )
+      null
+    end
+  end
+end
+
+# Obtain cover-art for a file. `null` is returned in case there is no
+# such information.
+# @category Metadata
+# @param file File from which the cover should be obtained
+def file.cover(fname) =
+  metadata.cover(file.metadata(fname))
+end
+
+# Remove cover metadata.
+# @category Metadata
+def metadata.cover.remove(m) =
+  list.assoc.filter(
+    fun (k, (_:string)) -> not list.mem(k, settings.encoder.metadata.cover()),
+    m
+  )
+end
+
+# Cleanup metadata for export. This is used to remove Liquidsoap's internal
+# metadata entries before sending them. List of exported metadata is set using
+# `settings.encoder.metadata.export.set`.
+# @category Metadata
+def metadata.export(m) =
+  exported_keys = settings.encoder.metadata.export()
+  list.assoc.filter((fun (k, (_:string)) -> list.mem(k, exported_keys)), m)
+end
+
+let metadata.json = ()
+
+# Export metadata as JSON object. Cover art, if found, is extracted using
+# `metadata.cover` and exported with key `"cover"` and exported using
+# `string.data_uri.encode`.
+# @category Metadata
+# @param ~coverart_mime Mime type to use for `"coverart"` metadata. Support disasbled if `null`.
+# @param ~compact Output compact text.
+# @param ~json5 Use json5 extended spec.
+def metadata.json.stringify(
+  ~coverart_mime=null,
+  ~base64=true,
+  ~compact=false,
+  ~json5=false,
+  m
+) =
+  c = metadata.cover(coverart_mime=coverart_mime, m)
+  m = metadata.cover.remove(m)
+  m = metadata.export(m)
+  m =
+    if
+      null.defined(c)
+    then
+      c = null.get(c)
+      [("cover", string.data_uri.encode(base64=base64, mime=c.mime, c)), ...m]
+    else
+      m
+    end
+
+  data = json.object()
+  list.iter(fun (v) -> data.add(fst(v), snd(v)), m)
+  json.stringify(json5=json5, compact=compact, data)
+end
+
+# Parse metadata from JSON object.
+# @category Metadata
+def metadata.json.parse(json_string) =
+  let json.parse (metadata_list : [(string*string)] as json.object) =
+    json_string
+
+  metadata_list
+end

--- a/tests/liq/nfo.liq
+++ b/tests/liq/nfo.liq
@@ -1,0 +1,258 @@
+# Parse XML `.nfo` sidecar files (Kodi/Emby/Jellyfin style).
+#
+# This is meant to be used either directly via `file.nfo.metadata(...)` or as a
+# metadata resolver through `enable_nfo_metadata(...)`.
+
+# @category File
+# @flag hidden
+let file.nfo = ()
+
+# @flag hidden
+def file.nfo._normalize_tag(name) =
+  name = string.trim(name)
+
+  # Strip XML namespace prefix, if any (e.g. "x:title" -> "title").
+  # This also tolerates a leading ":" (malformed XML) by stripping it.
+  name = r/^[^:]*:/.replace(fun (_) -> "", name)
+  string.case(name)
+end
+
+# Accumulate values by key.
+# @flag hidden
+def file.nfo._accum_add(key, value, acc) =
+  # Values are stored in reverse order for cheap cons.
+  # Assoc-list update is O(n) in distinct keys (NFOs are typically small).
+  let (rev, found) =
+    list.fold(
+      fun (st, kv) ->
+        begin
+          let (rev, found) = st
+          if
+            fst(kv) == key
+          then
+            ([(key, value::snd(kv)), ...rev], true)
+          else
+            ([kv, ...rev], found)
+          end
+        end,
+      ([], false),
+      acc
+    )
+
+  if found then list.rev(rev) else list.rev([(key, [value]), ...rev]) end
+end
+
+# Build a tag rule table for `.nfo` parsing.
+#
+# Returned rule tables can be reused across multiple calls to `file.nfo.metadata`.
+#
+# @category File
+# @param ~extra_rules Additional tag rules (prepended to built-ins).
+def file.nfo.rules(~extra_rules=[]) =
+  extra_rules =
+    list.map(
+      fun (r) ->
+        begin
+          let (tag, rule_fn) = r
+          (file.nfo._normalize_tag(tag), rule_fn)
+        end,
+      extra_rules
+    )
+
+  def uniqueid_rule(node, txt) =
+    typ = list.assoc.nullable("type", node.xml_params)
+    typ = null.map(fun (t) -> string.case(string.trim(t)), typ)
+
+    is_default =
+      null.case(
+        list.assoc.nullable("default", node.xml_params),
+        {false},
+        fun (d) -> string.case(string.trim(d)) == "true"
+      )
+
+    def without_type() =
+      # Missing or invalid `type` (legacy / malformed input).
+      is_default
+        ? [("uniqueid.default", txt), ("uniqueid.untyped", txt)]
+        : [("uniqueid.untyped", txt)]
+    end
+
+    def with_type(t) =
+      # Standard case: typed ID.
+      kvs = [("uniqueid." ^ t, txt)]
+      if
+        is_default
+      then
+        [("uniqueid.default", txt), ("uniqueid.default.type", t), ...kvs]
+      else
+        kvs
+      end
+    end
+
+    null.case(
+      typ,
+      {without_type()},
+      fun (t) ->
+        # Some scrapers incorrectly emit `type="default"`. Kodi warns against it,
+        # so we treat it as untyped.
+        (t == "" or t == "default") ? without_type() : with_type(t)
+    )
+  end
+
+  [...extra_rules, ("uniqueid", uniqueid_rule)]
+end
+
+# Extract metadata from an `.nfo` file.
+#
+# Returned metadata keys are namespaced under `nfo.*`.
+#
+# Currently, only direct children of the root element that contain textual
+# content are extracted.
+#
+# Special case:
+# - `<uniqueid type="X">VALUE</uniqueid>` is exported as `nfo.uniqueid.X=VALUE`.
+# - If `default="true"`, the ID is also exported as `nfo.uniqueid.default=VALUE` and
+#   the type as `nfo.uniqueid.default.type=X`.
+#   If multiple IDs are marked default, values are joined with `;`.
+# - Typeless `<uniqueid>` (or `type="default"`, a scraper quirk) is exported as
+#   `nfo.uniqueid.untyped=VALUE`.
+# - Repeated tags are joined with `;` (in order of appearance).
+# - Tag names and unique ID types are lowercased; namespace prefixes are ignored.
+#
+# @category File
+# @param ~rules Tag rules. Use `file.nfo.rules(...)` to build them.
+# @param nfo_file Path to the `.nfo` file.
+def file.nfo.metadata(~rules=file.nfo.rules(), nfo_file) =
+  if
+    not (file.exists(nfo_file))
+  then
+    []
+  else
+    try
+      s = file.contents(nfo_file)
+      let xml.parse ((root_name, root) :
+        (
+          string
+          *
+          {
+            xml_params: [(string * string)],
+            xml_children: [
+              (
+                string
+                *
+                {
+                  xml_params: [(string * string)],
+                  xml_children: [(string * {xml_text: string})]
+                }
+              )
+            ]
+          }
+        )
+      ) = s
+
+      root_name = file.nfo._normalize_tag(root_name)
+
+      def collect(fields, child) =
+        let (name, node) = child
+        name = file.nfo._normalize_tag(name)
+        txts =
+          list.filter_map(
+            fun (child) ->
+              begin
+                let (name, node) = child
+                if
+                  name != "xml_text"
+                then
+                  null
+                else
+                  txt = string.trim(node.xml_text)
+                  txt == "" ? null : txt
+                end
+              end,
+            node.xml_children
+          )
+
+        txt = list.case(txts, null, fun (txt, _) -> txt)
+
+        null.case(
+          txt,
+          {fields},
+          fun (txt) ->
+            begin
+              rule = list.assoc.nullable(name, rules)
+
+              kvs =
+                null.case(
+                  rule,
+                  {[(name, txt)]},
+                  fun (rule_fn) -> rule_fn(node, txt)
+                )
+
+              def add(fields, kv) =
+                let (k, v) = kv
+                file.nfo._accum_add(k, v, fields)
+              end
+
+              list.fold(add, fields, kvs)
+            end
+        )
+      end
+
+      fields_by_key = list.fold(collect, [], root.xml_children)
+
+      fields_md =
+        list.map(
+          fun (kv) ->
+            begin
+              let (k, vs) = kv
+              ("nfo." ^ k, string.concat(separator=";", list.rev(vs)))
+            end,
+          fields_by_key
+        )
+
+      [("nfo.root", root_name), ...fields_md]
+    catch e do
+      log.important(
+        label="file.nfo.metadata",
+        "Failed to parse nfo file #{string.quote(nfo_file)}: #{e.kind}: #{
+          e.message
+        }"
+      )
+      []
+    end
+  end
+end
+
+# Enable `.nfo` sidecar metadata resolver.
+#
+# For a media file `.../Foo.ext`, this looks for a sibling `.../Foo.nfo`.
+#
+# @category Liquidsoap
+# @param ~priority Resolver priority. Default is low to avoid overriding media tags.
+# @param ~mime_types Restrict to these MIME types (or `null` for any).
+# @param ~file_extensions Restrict to these file extensions (or `null` for any).
+# @param ~extra_rules Additional tag rules (prepended to built-ins).
+# @param ~rules Pre-built tag rule table. When provided, `extra_rules` is ignored.
+def enable_nfo_metadata(
+  ~priority={0},
+  ~mime_types=null,
+  ~file_extensions=null,
+  ~extra_rules=[],
+  ~rules=null
+) =
+  rules =
+    null.case(rules, {file.nfo.rules(extra_rules=extra_rules)}, fun (r) -> r)
+
+  def resolver(~metadata:_, file_name) =
+    nfo_file = path.remove_extension(file_name) ^ ".nfo"
+    file.nfo.metadata(rules=rules, nfo_file)
+  end
+
+  decoder.metadata.add(
+    priority=priority,
+    mime_types=mime_types,
+    file_extensions=file_extensions,
+    "nfo",
+    resolver
+  )
+end

--- a/tests/liq/null.liq
+++ b/tests/liq/null.liq
@@ -1,0 +1,71 @@
+# Determine whether a nullable value is not null.
+# @category Programming
+def _null.defined(x) =
+  null.case(x, {false}, fun (_) -> true)
+end
+
+# Get the value of a nullable. Raises `error.not_found` if the value is `null`
+# and no default value was specified.
+# @category Programming
+# @param ~default Returned value when the value is `null`.
+def _null.get(~default=null, x) =
+  null.case(
+    x,
+    {
+      default
+        ?? error.raise(
+          error.not_found,
+          "no default value for null.get"
+        )
+    },
+    fun (x) -> x
+  )
+end
+
+# Convert a nullable value to a list containing zero or one element depending on
+# whether the value is null or not.
+# @category Programming
+def _null.to_list(x) =
+  null.case(x, {[]}, fun (x) -> [x])
+end
+
+# Apply a function on a nullable value if it is not null, and return null
+# otherwise.
+# @category Programming
+def _null.map(f, x) =
+  null.case(x, {null}, fun (x) -> f(x))
+end
+
+# Find the first element of a list for which the image of the function is not
+# `null`. Raises `error.not_found` if not element is found and no default value
+# was specified.
+# @category Programming
+# @param ~default Returned value when no element is found.
+# @param f Function.
+# @param l List.
+def _null.find(~default=null, f, l) =
+  def rec aux(l) =
+    f =
+      list.case(
+        l,
+        {
+          default
+            ?? error.raise(
+              error.not_found,
+              "no default value for list.find_defined"
+            )
+        },
+        fun (x, l) ->
+          {
+            begin
+              y = f(x)
+              if null.defined(y) then y else aux(l) end
+            end
+          }
+      )
+
+    f()
+  end
+
+  aux(l)
+end

--- a/tests/liq/playlist.liq
+++ b/tests/liq/playlist.liq
@@ -1,0 +1,1347 @@
+let settings.playlist.mime_types =
+  settings.make.void(
+    "Mime-types used for guessing playlist formats."
+  )
+
+let playlist.parse.cue = ()
+
+# Parse a cue file
+# @category Liquidsoap
+# @param ~pwd Path to use for relative path resolution
+def playlist.parse.cue.full(~pwd=null, content) =
+  content = string.split(separator="[\r\n]+", content)
+
+  def parse_file(s) =
+    matches = r/^FILE (.+)$/.exec(string.trim(s))
+    try
+      match = list.assoc(1, matches)
+      match_chars = string.chars(match)
+
+      def rec get_last(~char, cur, chars) =
+        let [...chars, last] = chars
+        if
+          last == char
+        then
+          filename = string.concat(separator="", chars)
+          file_type = string.trim(string.concat(separator="", cur))
+          file_type =
+            if
+              file_type == ""
+            then
+              null
+            else
+              string.case(lower=true, file_type)
+            end
+          (filename, file_type)
+        else
+          get_last(char=char, [last, ...cur], chars)
+        end
+      end
+
+      let (filename, file_type) =
+        if
+          list.hd(match_chars) == '"'
+        then
+          let [_, ...chars] = match_chars
+          let (filename, file_type) = get_last(char='"', [], chars)
+          (string.unquote('"#{filename}"'), file_type)
+        else
+          get_last(
+            char=" ",
+            [],
+            match_chars
+          )
+        end
+
+      filename = playlist.parse.get_file(pwd=pwd, filename)
+      {filename = filename, file_type = file_type}
+    catch _ do
+      null
+    end
+  end
+
+  def parse_track_attribute(s) =
+    matches = r/^TRACK ([^\s]+)\s([^\s]+)?$/.exec(string.trim(s))
+    try
+      position = int_of_string(list.assoc(1, matches))
+      type = list.assoc(2, matches)
+
+      {position = position, track_type = string.case(lower=true, type)}
+    catch _ : [error.not_found] do
+      null
+    end
+  end
+
+  def parse_rem(s) =
+    matches = r/^REM ([^\s]+) (.+)$/.exec(string.trim(s))
+    try
+      name = string.case(lower=true, list.assoc(1, matches))
+      value = string.unquote(list.assoc(2, matches))
+      (name, value)
+    catch _ : [error.not_found] do
+      null
+    end
+  end
+
+  def parse_timecode(s) =
+    matches = r/^([\d]+):([\d]+):([\d]+)/.exec(string.trim(s))
+    try
+      minutes = int_of_string(list.assoc(1, matches))
+      seconds = int_of_string(list.assoc(2, matches))
+      frames = int_of_string(list.assoc(3, matches))
+
+      {minutes = minutes, seconds = seconds, frames = frames}
+    catch _ : [error.not_found] do
+      null
+    end
+  end
+
+  def parse_index(s) =
+    matches = r/^INDEX ([\d]+) ([\d:]+)/.exec(string.trim(s))
+    try
+      index = int_of_string(list.assoc(1, matches))
+      timecode = list.assoc(2, matches)
+
+      (index, null.get(parse_timecode(timecode)))
+    catch _ do
+      null
+    end
+  end
+
+  def parse_optional(~label, s) =
+    matches =
+      regexp(
+        "^#{string.case(lower=false, label)} (.+)$"
+      ).exec(string.trim(s))
+    null.map(string.unquote, list.assoc.nullable(1, matches))
+  end
+
+  def end_parse_track(content) =
+    content == [] or null.defined(parse_track_attribute(list.hd(content)))
+  end
+
+  def rec parse_track(~file, ~track, content) =
+    track =
+      (track :
+        {
+          position: int,
+          track_type?: string,
+          performer?: string,
+          title?: string,
+          album?: string,
+          isrc?: string,
+          postgap?: {minutes: int, seconds: int, frames: int},
+          pregap?: {minutes: int, seconds: int, frames: int},
+          indexes: [
+            (
+              int
+              *
+              {
+                filename?: string,
+                file_type?: string,
+                minutes: int,
+                seconds: int,
+                frames: int
+              }
+            )
+          ]
+        }
+      )
+
+    if
+      end_parse_track(content)
+    then
+      (file, track, content)
+    else
+      let [s, ...content] = content
+
+      index = parse_index(s)
+      new_file = parse_file(s)
+
+      let (file, track) =
+        if
+          null.defined(index)
+        then
+          let (idx, timecode) = null.get(index)
+          (
+            file,
+            {
+              ...track,
+              indexes = [...track.indexes, (idx, {...file, ...timecode})]
+            }
+          )
+        elsif
+          null.defined(new_file)
+        then
+          (new_file, track)
+        else
+          track_attributes =
+            [
+              ("title", fun (title) -> {...track, title = title}),
+              (
+                "performer",
+                fun (performer) -> {...track, performer = performer}
+              ),
+              (
+                "pregap",
+                fun (pregap) ->
+                  {...track, pregap = null.get(parse_timecode(pregap))}
+              ),
+              (
+                "postgap",
+                fun (postgap) ->
+                  {...track, postgap = null.get(parse_timecode(postgap))}
+              ),
+              (
+                "rem",
+                fun (rem) ->
+                  begin
+                    parsed =
+                      parse_rem(
+                        "REM #{rem}"
+                      )
+                    if
+                      null.defined(parsed)
+                    then
+                      let (label, value) = null.get(parsed)
+                      if
+                        label == "album"
+                      then
+                        {...track, album = value}
+                      else
+                        log.important(
+                          label="playlist.parse.cue.full",
+                          "Unknown track attribute REM #{rem}, please file a bug \
+                           report!"
+                        )
+                        track
+                      end
+                    end
+                  end
+              ),
+              ("isrc", fun (isrc) -> {...track, isrc = isrc})
+            ]
+          attribute_names = list.map(fst, track_attributes)
+
+          def rec check_attribute(attribute_names) =
+            if
+              attribute_names == []
+            then
+              log.important(
+                label="playlist.parse.cue.full",
+                "Could not parse track attribute: #{s}"
+              )
+              track
+            else
+              let [name, ...attribute_names] = attribute_names
+              let fn = list.assoc(name, track_attributes)
+              parsed = parse_optional(label=name, s)
+
+              if
+                null.defined(parsed)
+              then
+                fn(null.get(parsed))
+              else
+                check_attribute(attribute_names)
+              end
+            end
+          end
+
+          (file, check_attribute(attribute_names))
+        end
+      parse_track(file=file, track=track, content)
+    end
+  end
+
+  def rec parse_content(~file, ~sheet, content) =
+    sheet =
+      (sheet :
+        {
+          catalog?: string,
+          performer?: string,
+          title?: string,
+          rem: [(string * string)],
+          tracks: [
+            {
+              position: int,
+              track_type?: string,
+              performer?: string,
+              title?: string,
+              album?: string,
+              isrc?: string,
+              postgap?: {minutes: int, seconds: int, frames: int},
+              pregap?: {minutes: int, seconds: int, frames: int},
+              indexes: [
+                (
+                  int
+                  *
+                  {
+                    filename?: string,
+                    file_type?: string,
+                    minutes: int,
+                    seconds: int,
+                    frames: int
+                  }
+                )
+              ]
+            }
+          ]
+        }
+      )
+
+    if
+      content == []
+    then
+      sheet
+    else
+      let [s, ...content] = content
+
+      new_file = parse_file(s)
+      new_rem = parse_rem(s)
+      track = parse_track_attribute(s)
+
+      if
+        null.defined(new_file)
+      then
+        parse_content(file=new_file, sheet=sheet, content)
+      elsif
+        null.defined(new_rem)
+      then
+        parse_content(
+          file=file,
+          sheet={...sheet, rem = [null.get(new_rem), ...sheet.rem]},
+          content
+        )
+      elsif
+        null.defined(track)
+      then
+        let (file, track, content) =
+          parse_track(
+            file=file,
+            track={...null.get(track), indexes = []},
+            content
+          )
+        parse_content(
+          file=file,
+          sheet={...sheet, tracks = [...sheet.tracks, track]},
+          content
+        )
+      else
+        sheet_attributes =
+          [
+            ("catalog", fun (catalog) -> {...sheet, catalog = catalog}),
+            ("performer", fun (performer) -> {...sheet, performer = performer}),
+            ("title", fun (title) -> {...sheet, title = title})
+          ]
+
+        attribute_names = list.map(fst, sheet_attributes)
+
+        def rec check_attribute(attribute_names) =
+          if
+            attribute_names == []
+          then
+            log.important(
+              label="playlist.parse.cue.full",
+              "Could not parse attribute: #{string.quote(s)}"
+            )
+            sheet
+          else
+            let [name, ...attribute_names] = attribute_names
+            let fn = list.assoc(name, sheet_attributes)
+            let parsed = parse_optional(label=name, s)
+
+            if
+              null.defined(parsed)
+            then
+              fn(null.get(parsed))
+            else
+              check_attribute(attribute_names)
+            end
+          end
+        end
+
+        parse_content(
+          file=file,
+          sheet=check_attribute(attribute_names),
+          content
+        )
+      end
+    end
+  end
+
+  parse_content(file=null, sheet={tracks = [], rem = []}, content)
+end
+
+let settings.playlist.cue =
+  settings.make.void(
+    "Settings for parsing cue files"
+  )
+
+let settings.playlist.cue.pregap_metadata =
+  settings.make(
+    description="Metadata used to pass pre-gap cue metadata",
+    "liq_pregap"
+  )
+
+let settings.playlist.cue.index_zero_metadata =
+  settings.make(
+    description="Metadata used to pass index 0 cue metadata",
+    "liq_index_zero"
+  )
+
+let settings.playlist.cue.index_zero_filename_metadata =
+  settings.make(
+    description="Metadata used to pass index 0 filename metadata",
+    "liq_index_zero_filename"
+  )
+
+let settings.playlist.cue.postgap_metadata =
+  settings.make(
+    description="Metadata used to pass pre-gap cue metadata",
+    "liq_postgap"
+  )
+
+# Parse a cue file and return a value suitable for playlist parser registration.
+# @category Liquidsoap
+# @param ~pwd Path to use for relative path resolution
+def replaces playlist.parse.cue(~pwd=null, content) =
+  # Simple test: playlist should have at least one file..
+  if
+    r/FILE/.test(content)
+  then
+    let {catalog?, title?, performer?, rem, tracks} =
+      playlist.parse.cue.full(pwd=pwd, content)
+    let playlist_album = title
+    let album_performer = performer
+    rem =
+      list.map(
+        fun (el) ->
+          begin
+            let (name, value) = el
+            if name == "date" then ("year", value) else (name, value) end
+          end,
+        rem
+      )
+
+    def seconds_of_timecode(timecode) =
+      let {minutes, seconds, frames} = timecode
+      float(minutes) * 60. + float(seconds) + float(frames) / 75.
+    end
+
+    def string_of_timecode(timecode) =
+      string(seconds_of_timecode(timecode))
+    end
+
+    def add_track(tracks, track) =
+      let {
+        performer?,
+        title?,
+        album?,
+        isrc?,
+        pregap?,
+        postgap?,
+        position,
+        indexes
+      } = track
+      index_zero = list.assoc.nullable(0, indexes)
+      index_zero_filename = null.map(fun (m) -> m?.filename, index_zero)
+      index = list.assoc.nullable(1, indexes)
+      filename = null.map(fun (m) -> m?.filename, index)
+      cue_in_metadata = settings.playlist.cue_in_metadata()
+      cue_out_metadata = settings.playlist.cue_out_metadata()
+      pregap_metadata = settings.playlist.cue.pregap_metadata()
+      index_zero_metadata = settings.playlist.cue.index_zero_metadata()
+      index_zero_filename_metadata =
+        settings.playlist.cue.index_zero_filename_metadata()
+      postgap_metadata = settings.playlist.cue.postgap_metadata()
+
+      if
+        not null.defined(filename) or (not null.defined(index))
+      then
+        log.important(
+          label="playlist.cue.parse",
+          "Track without filename or index: #{track}"
+        )
+        tracks
+      else
+        let timecode = null.get(index)
+        let filename = null.get(filename)
+
+        timecode = seconds_of_timecode(timecode)
+        cue_in = timecode == 0. ? [] : [(cue_in_metadata, string(timecode))]
+
+        cue_out =
+          try
+            let (old_meta, old_filename) = list.hd(tracks)
+            if
+              old_filename == filename
+            then
+              index_zero = list.assoc(default="", index_zero_metadata, old_meta)
+
+              cue_out =
+                if
+                  index_zero != ""
+                then
+                  index_zero
+                else
+                  list.assoc(cue_in_metadata, old_meta)
+                end
+
+              [(cue_out_metadata, cue_out)]
+            else
+              []
+            end
+          catch _ do
+            []
+          end
+
+        meta =
+          list.fold(
+            fun (meta, el) ->
+              begin
+                let (name, value) = el
+                if
+                  null.defined(value)
+                then
+                  [(name, null.get(value)), ...meta]
+                else
+                  meta
+                end
+              end,
+            [],
+            [
+              (pregap_metadata, null.map(string_of_timecode, pregap)),
+              (postgap_metadata, null.map(string_of_timecode, postgap)),
+              (index_zero_metadata, null.map(string_of_timecode, index_zero)),
+              (index_zero_filename_metadata, index_zero_filename),
+              ("tracknumber", string(position)),
+              ("catalog", catalog),
+              ...(
+                null.defined(performer)
+                  ? [("artist", performer), ("albumartist", album_performer)]
+                  : [("artist", album_performer)]
+              ),
+              ("title", title),
+              ("isrc", isrc),
+              ("album", album ?? playlist_album)
+            ]
+          )
+
+        [([...cue_in, ...cue_out, ...meta, ...rem], filename), ...tracks]
+      end
+    end
+
+    list.fold(add_track, [], list.rev(tracks))
+  else
+    []
+  end
+end
+
+let settings.playlist.mime_types.basic =
+  settings.make(
+    description="Mime-types used for guessing text-based playlists.",
+    [
+      {
+        name =
+          "scpls format",
+        mimes = ["audio/x-scpls"],
+        strict = true,
+        parser = playlist.parse.scpls
+      },
+      {
+        name =
+          "cue sheet",
+        mimes = ["application/x-cue"],
+        strict = true,
+        parser = playlist.parse.cue
+      },
+      {
+        name =
+          "m3u Format",
+        mimes = ["audio/x-mpegurl", "audio/mpegurl", "application/x-mpegURL"],
+        strict = false,
+        parser = playlist.parse.m3u
+      }
+    ]
+  )
+
+%ifdef playlist.parse.xml
+let settings.playlist.mime_types.xml =
+  settings.make(
+    description="Mime-types used for guessing xml-based playlists.",
+    [
+      {
+        name =
+          "xmlplaylist format",
+        mimes =
+          [
+            "video/x-ms-asf",
+            "audio/x-ms-asx",
+            "text/xml",
+            "application/xml",
+            "application/smil",
+            "application/smil+xml",
+            "application/xspf+xml",
+            "application/rss+xml"
+          ],
+        strict = true,
+        parser = playlist.parse.xml
+      }
+    ]
+  )
+%endif
+
+# @flag hidden
+let register_playlist_parsers =
+  begin
+    registered = ref(false)
+    fun () ->
+      begin
+        if
+          not registered()
+        then
+          parsers = settings.playlist.mime_types.basic()
+%ifdef playlist.parse.xml
+          parsers = [...parsers, ...settings.playlist.mime_types.xml()]
+%endif
+          list.iter(
+            fun ({name, mimes, strict, parser}) ->
+              playlist.parse.register(
+                name=name,
+                mimes=mimes,
+                strict=strict,
+                parser
+              ),
+            parsers
+          )
+        end
+        registered := true
+      end
+  end
+on_start(register_playlist_parsers)
+
+# @docof playlist.parse
+def replaces playlist.parse(%argsof(playlist.parse), uri) =
+  register_playlist_parsers()
+  playlist.parse(%argsof(playlist.parse), uri)
+end
+
+# Default id assignment for playlists (the identifier is generated from the
+# filename).
+# @category Liquidsoap
+# @flag hidden
+# @param ~default Default name pattern when no useful name can be extracted from `uri`
+# @param uri Playlist uri
+def playlist.id(~default, uri) =
+  basename = path.basename(uri)
+  basename =
+    if
+      basename == "."
+    then
+      let l = r/\//g.split(uri)
+      if l == [] then path.dirname(uri) else list.hd(list.rev(l)) end
+    else
+      basename
+    end
+
+  if
+    basename == "."
+  then
+    string.id.default(default=default, null)
+  else
+    basename
+  end
+end
+
+# Retrieve the list of files contained in a playlist.
+# @category File
+# @param ~mime_type Default MIME type for the playlist. `null` means automatic detection.
+# @param ~timeout Timeout for resolving the playlist
+# @param uri Path to the playlist
+def playlist.files(~id=null, ~mime_type=null, ~timeout=null, uri) =
+  id = id ?? playlist.id(default="playlist.files", uri)
+
+  if
+    file.is_directory(uri)
+  then
+    log.info(
+      label=id,
+      "Playlist is a directory."
+    )
+    files = file.ls(absolute=true, recursive=true, sorted=true, uri)
+    files = list.filter(fun (f) -> not (file.is_directory(f)), files)
+    files
+  else
+    pl = request.create(resolve_metadata=false, uri)
+    result =
+      if
+        request.resolve(timeout=timeout, pl)
+      then
+        pl = request.filename(pl)
+        files = playlist.parse(mime=mime_type, pl)
+
+        def file_request(el) =
+          let (meta, file) = el
+          s =
+            string.concat(
+              separator=",",
+              list.map(fun (el) -> "#{fst(el)}=#{string.quote(snd(el))}", meta)
+            )
+
+          if s == "" then file else "annotate:#{s}:#{file}" end
+        end
+
+        list.map.right(file_request, files)
+      else
+        log.important(
+          label=id,
+          "Couldn't read playlist: request resolution failed."
+        )
+        request.destroy(pl)
+
+        error.raise(
+          error.invalid,
+          "Could not resolve uri: #{uri}"
+        )
+      end
+
+    request.destroy(pl)
+    result
+  end
+end
+
+%ifdef native
+let stdlib_native = native
+%endif
+
+# Play a list of files.
+# @category Source / Input / Passive
+# @param ~id Force the value of the source ID.
+# @param ~check_next Function used to filter next tracks. A candidate track is \
+#   only validated if the function returns true on it. The function is called \
+#   before resolution, hence metadata will only be available for requests \
+#   corresponding to local files. This is typically used to avoid repetitions, \
+#   but be careful: if the function rejects all attempts, the playlist will \
+#   enter into a consuming loop and stop playing anything.
+# @param ~prefetch How many requests should be queued in advance.
+# @param ~loop Loop on the playlist.
+# @param ~mode Play the files in the playlist either in the order ("normal" mode), \
+#  or shuffle the playlist each time it is loaded, and play it in this order for a \
+#  whole round ("randomize" mode), or pick a random file in the playlist each time \
+#  ("random" mode).
+# @param ~native Use native implementation, when available.
+# @param ~on_loop Function executed when the playlist is about to loop.
+# @param ~on_done Function executed when the playlist is finished.
+# @param ~max_fail When this number of requests fail to resolve, the whole playlists is considered as failed and `on_fail` is called.
+# @param ~on_fail Function executed when too many requests failed and returning the contents of a fixed playlist.
+# @param ~timeout Timeout (in sec.) to resolve the request. Defaults to `settings.request.timeout` when `null`.
+# @param ~cue_in_metadata Metadata for cue in points. Disabled if `null`.
+# @param ~cue_out_metadata Metadata for cue out points. Disabled if `null`.
+# @param playlist Playlist.
+# @method reload Reload the playlist with given list of songs.
+# @method remaining_files Songs remaining to be played.
+def playlist.list(
+  ~id=null,
+  ~check_next=null,
+  ~prefetch=null,
+  ~loop=true,
+  ~mode="normal",
+  ~native=false,
+  ~on_loop={()},
+  ~on_done={()},
+  ~max_fail=10,
+  ~on_fail=null,
+  ~timeout=null,
+  ~cue_in_metadata=null("liq_cue_in"),
+  ~cue_out_metadata=null("liq_cue_out"),
+  playlist
+) =
+  ignore(native)
+  id = string.id.default(default="playlist.list", id)
+  mode =
+    if
+      not list.mem(mode, ["normal", "random", "randomize"])
+    then
+      log.severe(
+        label=id,
+        "Invalid mode: #{mode}"
+      )
+      "randomize"
+    else
+      mode
+    end
+
+  check_next = check_next ?? fun (_) -> true
+  should_stop = ref(false)
+  on_shutdown({should_stop.set(true)})
+  on_fail =
+    null.map(
+      fun (on_fail) -> {if not should_stop() then on_fail() else [] end},
+      on_fail
+    )
+
+  # Original playlist when loaded
+  playlist_orig = ref(playlist)
+
+  # Randomize the playlist if necessary
+  def randomize(p) =
+    if mode == "randomize" then list.shuffle(p) else p end
+  end
+
+  # Current remaining playlist
+  playlist = ref(randomize(playlist))
+
+  # A reference to know if the source has been stopped
+  has_stopped = ref(false)
+
+  # Delay the creation of next after the source because we need it to resolve
+  # requests at the right content type.
+  next_fun = ref(fun () -> null)
+
+  def next() =
+    f = next_fun()
+    f()
+  end
+
+  # Instantiate the source
+  default =
+    fun () ->
+      request.dynamic(
+        id=id,
+        prefetch=prefetch,
+        timeout=timeout,
+        retry_delay=1.,
+        available={not has_stopped()},
+        next
+      )
+
+  s =
+%ifdef native
+    if native then stdlib_native.request.dynamic(id=id, next) else default() end
+%else
+    default()
+%endif
+
+  # Prevent concurrent reload and next()
+  is_reloading = ref(false)
+  pending_next = ref(false)
+
+  # The reload function
+  def reload(~empty_queue=true, p) =
+    is_reloading := true
+
+    log.debug(
+      label=id,
+      "Reloading playlist."
+    )
+    playlist_orig := p
+    playlist := randomize(playlist_orig())
+    has_stopped := false
+    if
+      empty_queue
+    then
+      q = s.queue()
+      s.set_queue([])
+      list.iter(request.destroy, q)
+      pending_next := true
+    end
+
+    if pending_next() then s.fetch() end
+
+    pending_next := false
+    is_reloading := false
+  end
+
+  # When we have more than max_fail failures in a row, we wait for 1 second
+  # before trying again in order to avoid infinite loops.
+  failed_count = ref(0)
+  failed_time = ref(0.)
+
+  # The (real) next function
+  def rec next() =
+    if
+      is_reloading()
+    then
+      pending_next := true
+    elsif
+      loop and list.is_empty(playlist())
+    then
+      on_loop()
+
+      # The above function might have reloaded the playlist
+      if
+        list.is_empty(playlist())
+      then
+        playlist := randomize(playlist_orig())
+      end
+    end
+
+    file =
+      if
+        list.length(playlist()) > 0
+      then
+        if
+          mode == "random"
+        then
+          n = random.int(min=0, max=list.length(playlist()))
+          list.nth(default="", playlist(), n)
+        else
+          ret = list.hd(default="", playlist())
+          playlist := list.tl(playlist())
+          ret
+        end
+      else
+        # Playlist finished
+        if
+          not has_stopped()
+        then
+          has_stopped := true
+          log.info(
+            label=id,
+            "Playlist stopped."
+          )
+          on_done()
+        end
+
+        ""
+      end
+
+    if
+      file == "" or (failed_count() >= max_fail and time() < failed_time() + 1.)
+    then
+      # Playlist failed too many times recently, don't try next for now.
+      null
+    else
+      log.debug(
+        label=id,
+        "Next song will be \"#{file}\"."
+      )
+
+      r =
+        request.create(
+          cue_in_metadata=cue_in_metadata,
+          cue_out_metadata=cue_out_metadata,
+          file
+        )
+
+      if
+        check_next(r)
+      then
+        if
+          not request.resolve(r)
+        then
+          log.info(
+            label=id,
+            "Could not resolve request: #{request.uri(r)}."
+          )
+          request.destroy(r)
+          ref.incr(failed_count)
+
+          # Playlist failed, call handler.
+          if
+            failed_count() < max_fail
+          then
+            log.info(
+              label=id,
+              "Playlist failed."
+            )
+            if
+              null.defined(on_fail)
+            then
+              f = null.get(on_fail)
+              reload(f())
+            end
+          end
+
+          failed_time := time()
+          (next() : request?)
+        else
+          failed_count := 0
+          r
+        end
+      else
+        log.info(
+          label=id,
+          "Request #{request.uri(r)} rejected by check_next."
+        )
+
+        request.destroy(r)
+        next()
+      end
+    end
+  end
+
+  next_fun := next
+
+  # List of songs remaining to be played
+  def remaining_files() =
+    playlist()
+  end
+
+  # Return
+  s.{reload = reload, remaining_files = remaining_files}
+end
+
+# Read a playlist or a directory and play all files.
+# @category Source / Input / Passive
+# @param ~id Force the value of the source ID.
+# @param ~check_next Function used to filter next tracks. A candidate track is \
+#   only validated if the function returns true on it. The function is called \
+#   before resolution, hence metadata will only be available for requests \
+#   corresponding to local files. This is typically used to avoid repetitions, \
+#   but be careful: if the function rejects all attempts, the playlist will \
+#   enter into a consuming loop and stop playing anything.
+# @param ~prefetch How many requests should be queued in advance.
+# @param ~loop Loop on the playlist.
+# @param ~mime_type Default MIME type for the playlist. `null` means automatic \
+#  detection.
+# @param ~mode Play the files in the playlist either in the order ("normal" mode), \
+#  or shuffle the playlist each time it is loaded, and play it in this order for a \
+#  whole round ("randomize" mode), or pick a random file in the playlist each time \
+#  ("random" mode).
+# @param ~native Use native implementation.
+# @param ~max_fail When this number of requests fail to resolve, the whole playlists is considered as failed and `on_fail` is called.
+# @param ~on_done Function executed when the playlist is finished.
+# @param ~on_fail Function executed when too many requests failed and returning the contents of a fixed playlist.
+# @param ~on_reload Callback called after playlist has reloaded.
+# @param ~prefix Add a constant prefix to all requests. Useful for passing extra \
+#  information using annotate, or for resolution through a particular protocol, \
+#  such as replaygain.
+# @param ~reload Amount of time (in seconds or rounds), when applicable, before \
+#  which the playlist is reloaded; 0 means never.
+# @param ~reload_mode Unit of the reload parameter, either "never" (never reload \
+#  the playlist), "rounds", "seconds" or "watch" (reload the file whenever it is \
+#  changed).
+# @param ~register_server_commands Register corresponding server commands
+# @param ~timeout Timeout (in sec.) to resolve the request. Defaults to `settings.request.timeout` when `null`.
+# @param ~cue_in_metadata Metadata for cue in points. Disabled if `null`.
+# @param ~cue_out_metadata Metadata for cue out points. Disabled if `null`.
+# @param uri Playlist URI.
+# @method reload Reload the playlist.
+# @method length Length of the of the playlist (the number of songs it contains).
+# @method remaining_files Songs remaining to be played.
+def replaces playlist(
+  ~id=null,
+  ~check_next=null,
+  ~prefetch=null,
+  ~loop=true,
+  ~max_fail=10,
+  ~mime_type=null,
+  ~mode="randomize",
+  ~native=false,
+  ~on_done={()},
+  ~on_fail=null,
+  ~on_reload=(fun (_) -> ()),
+  ~prefix="",
+  ~reload=0,
+  ~reload_mode="seconds",
+  ~timeout=null,
+  ~cue_in_metadata=null("liq_cue_in"),
+  ~cue_out_metadata=null("liq_cue_out"),
+  ~register_server_commands=true,
+  uri
+) =
+  id = id ?? playlist.id(default="playlist", uri)
+  reload_mode =
+    if
+      not list.mem(reload_mode, ["never", "rounds", "seconds", "watch"])
+    then
+      log.severe(
+        label=id,
+        "Invalid reload mode: #{mode}"
+      )
+      "seconds"
+    else
+      reload_mode
+    end
+
+  round = ref(0)
+
+  # URI of the current playlist
+  playlist_uri = ref(uri)
+
+  # List of files in the current playlist
+  files = ref([])
+
+  # The reload function
+  reloader_ref = ref(fun (~empty_queue=true) -> ignore(empty_queue))
+
+  failed_loads = ref(0)
+
+  # The load function
+  def load_playlist() =
+    playlist_uri = path.home.unrelate(playlist_uri())
+
+    log.info(
+      label=id,
+      "Reloading playlist."
+    )
+
+    files =
+      try
+        playlist.files(
+          id=id,
+          mime_type=mime_type,
+          timeout=timeout,
+          playlist_uri
+        )
+      catch err do
+        log.info(
+          label=id,
+          "Playlist load failed: #{err}"
+        )
+
+        ref.incr(failed_loads)
+
+        if
+          failed_loads() < max_fail
+        then
+          []
+        else
+          log.info(
+            label=id,
+            "Maximum failures reached!"
+          )
+          on_fail = on_fail ?? fun () -> []
+          on_fail()
+        end
+      end
+
+    list.map.right(fun (file) -> prefix ^ file, files)
+  end
+
+  # Reload when the playlist is done
+  def on_loop() =
+    reloader = reloader_ref()
+    if
+      reload_mode == "rounds" and reload > 0
+    then
+      round := round() + 1
+      if
+        round() >= reload
+      then
+        round := 0
+        reloader()
+      end
+    end
+  end
+
+  watcher_reload_ref = ref(fun (_) -> ())
+
+  def on_reload(uri) =
+    watcher_reload = watcher_reload_ref()
+    watcher_reload(uri)
+    on_reload(uri)
+  end
+
+  s =
+    playlist.list(
+      id=id,
+      check_next=check_next,
+      prefetch=prefetch,
+      loop=loop,
+      max_fail=max_fail,
+      mode=mode,
+      native=native,
+      on_done=on_done,
+      on_loop=on_loop,
+      on_fail=on_fail,
+      timeout=timeout,
+      cue_in_metadata=cue_in_metadata,
+      cue_out_metadata=cue_out_metadata,
+      files()
+    )
+
+  is_loading = ref(false)
+  def if_not_reloading(fn) =
+    if
+      not is_loading()
+    then
+      is_loading := true
+      try
+        fn()
+      finally
+        is_loading := false
+      end
+    end
+  end
+
+  s.on_wake_up(
+    synchronous=false,
+    memoize(
+      {
+        if_not_reloading(
+          fun () ->
+            begin
+              log(
+                label=s.id(),
+                "Initial load with URI #{playlist_uri()}."
+              )
+              files := load_playlist()
+              s.reload(empty_queue=true, files())
+            end
+        )
+      }
+    )
+  )
+
+  # The reload function
+  def s.reload(~empty_queue=true, ~uri=null) =
+    if_not_reloading(
+      fun () ->
+        if
+          failed_loads() < max_fail
+        then
+          if null.defined(uri) then playlist_uri := null.get(uri) end
+          log(
+            label=s.id(),
+            "Reloading playlist with URI #{playlist_uri()}."
+          )
+          files := load_playlist()
+          s.reload(empty_queue=empty_queue, files())
+          on_reload(playlist_uri())
+        end
+    )
+  end
+
+  reloader_ref := s.reload
+
+  def s.length() =
+    list.length(files())
+  end
+
+  # Set up reloading for seconds and watch
+  if
+    reload_mode == "seconds" and reload > 0
+  then
+    n = float_of_int(reload)
+    thread.run(delay=n, every=n, s.reload)
+  elsif
+    reload_mode == "watch"
+  then
+    watcher =
+      if
+        file.exists(playlist_uri())
+      then
+        ref(null(file.watch(playlist_uri(), s.reload)))
+      else
+        ref(null)
+      end
+
+    watched_uri = ref(playlist_uri())
+
+    def watcher_reload(uri) =
+      if
+        uri != watched_uri()
+      then
+        w = watcher()
+        if null.defined(w) then null.get(w).unwatch() end
+        watched_uri := uri
+        watcher :=
+          if file.exists(uri) then file.watch(uri, s.reload) else null end
+      end
+    end
+
+    watcher_reload_ref := watcher_reload
+
+    def watcher_shutdown() =
+      w = watcher()
+      if null.defined(w) then null.get(w).unwatch() end
+    end
+
+    s.on_shutdown(synchronous=true, watcher_shutdown)
+  end
+
+  if
+    register_server_commands
+  then
+    # Set up telnet commands
+    s.register_command(
+      description="Skip current song in the playlist.",
+      usage="skip",
+      "skip",
+      fun (_) ->
+        begin
+          s.skip()
+          "OK"
+        end
+    )
+
+    s.register_command(
+      description="Return up to 10 next URIs to be played.",
+      usage="next",
+      "next",
+      fun (n) ->
+        begin
+          n = max(10, int_of_string(default=10, n))
+          requests =
+            list.fold(
+              (fun (cur, el) -> list.length(cur) < n ? [...cur, el] : cur),
+              [],
+              s.queue()
+            )
+
+          string.concat(
+            separator="\n",
+            list.map(
+              (
+                fun (r) ->
+                  begin
+                    m = request.metadata(r)
+                    get = fun (lbl) -> list.assoc(default="?", lbl, m)
+                    status = get("status")
+                    uri = get("initial_uri")
+                    "[#{status}] #{uri}"
+                  end
+              ),
+              requests
+            )
+          )
+        end
+    )
+
+    s.register_command(
+      description="Reload the playlist, unless already being loaded.",
+      usage="reload",
+      "reload",
+      fun (_) ->
+        begin
+          s.reload()
+          "OK"
+        end
+    )
+
+    def uri_cmd(uri') =
+      if
+        uri' == ""
+      then
+        playlist_uri()
+      else
+        if
+          reload_mode == "watch"
+        then
+          log.important(
+            label=id,
+            "Warning: the watched file is not updated for now when changing the \
+             uri!"
+          )
+        end
+
+        # TODO
+        playlist_uri := uri'
+        s.reload(uri=uri')
+        "OK"
+      end
+    end
+
+    s.register_command(
+      description="Print playlist URI if called without an argument, otherwise \
+       set a new one and load it.",
+      usage="uri [<uri>]",
+      "uri",
+      uri_cmd
+    )
+  end
+
+  s
+end

--- a/tests/liq/predicate.liq
+++ b/tests/liq/predicate.liq
@@ -1,0 +1,106 @@
+predicate = ()
+
+# Detect when a predicate becomes true.
+# @category Programming
+# @param ~init Detect at beginning.
+# @param p Predicate.
+def predicate.activates(~init=false, p) =
+  last = ref(not init)
+  fun () ->
+    begin
+      cur = p()
+      ans = (not last()) and cur
+      last := cur
+      ans
+    end
+end
+
+# Become true once every time a predicate is true.
+# @category Programming
+# @param p Predicate.
+def predicate.once(p) =
+  predicate.activates(init=true, p)
+end
+
+# Limit the number of times a predicate is true is a row.
+# @category Programming
+# @param n Number of times the predicate is allowed to be true.
+# @param p Predicate.
+def predicate.at_most(n, p) =
+  k = ref(0)
+  fun () ->
+    begin
+      if
+        p()
+      then
+        ref.incr(k)
+        k() <= n
+      else
+        k := 0
+        false
+      end
+    end
+end
+
+# Detect when a predicate changes.
+# @category Programming
+# @param p Predicate.
+def predicate.changes(p) =
+  last = ref(p())
+  fun () ->
+    begin
+      cur = p()
+      ans = (cur != last())
+      last := cur
+      ans
+    end
+end
+
+# First occurrence of a predicate.
+# @category Programming
+# @param p Predicate.
+def predicate.first(p) =
+  done = ref(false)
+  fun () ->
+    begin
+      if
+        done()
+      then
+        false
+      else
+        if
+          p()
+        then
+          done := true
+          true
+        else
+          false
+        end
+      end
+    end
+end
+
+# Predicate which is true when a signal is sent. The returned predicate has a
+# method `signal` to send the signal.
+# @category Programming
+# @method signal Send a signal.
+def predicate.signal() =
+  state = ref(false)
+
+  def signal() =
+    state := true
+  end
+
+  def p() =
+    if
+      state()
+    then
+      state := false
+      true
+    else
+      false
+    end
+  end
+
+  p.{signal = signal}
+end

--- a/tests/liq/process.liq
+++ b/tests/liq/process.liq
@@ -1,0 +1,93 @@
+# Perform a shell call and return its output.
+# @category System
+# @param ~timeout Cancel process after `timeout` has elapsed. Ignored if negative.
+# @param ~env Process environment
+# @param ~inherit_env Inherit calling process's environment when `env` parameter is empty.
+# @param ~log_errors Log details if the command does not return 0.
+# @param command Command to run
+def process.read(
+  ~timeout=(-1.),
+  ~env=[],
+  ~inherit_env=true,
+  ~log_errors=true,
+  command
+) =
+  p = process.run(timeout=timeout, env=env, inherit_env=inherit_env, command)
+  if
+    log_errors and (p.status != "exit" or p.status.code != 0)
+  then
+    log.important(
+      "Failed to execute `#{command}`: #{p.status} (#{p.status.code}) #{
+        p.stdout
+      } #{p.stderr}"
+    )
+  end
+
+  p.stdout
+end
+
+# Perform a shell call and return the list of its output lines.
+# @category System
+# @param ~timeout Cancel process after `timeout` has elapsed. Ignored if negative.
+# @param ~env Process environment
+# @param ~inherit_env Inherit calling process's environment when `env` parameter is empty.
+# @param ~log_errors Log details if the command does not return 0.
+# @param command Command to run
+def process.read.lines(
+  ~timeout=(-1.),
+  ~env=[],
+  ~inherit_env=true,
+  ~log_errors=true,
+  command
+) =
+  s =
+    process.read(
+      timeout=timeout,
+      env=env,
+      inherit_env=inherit_env,
+      log_errors=log_errors,
+      command
+    )
+
+  r/\r?\n/.split(s)
+end
+
+# Return true if process exited with 0 code.
+# @category System
+# @param ~timeout Cancel process after `timeout` has elapsed. Ignored if negative.
+# @param ~env Process environment
+# @param ~inherit_env Inherit calling process's environment when `env` parameter is empty.
+# @param command Command to test
+def process.test(~timeout=(-1.), ~env=[], ~inherit_env=true, command) =
+  p = process.run(timeout=timeout, env=env, inherit_env=inherit_env, command)
+  p.status == "exit" and p.status.code == 0
+end
+
+# Read some value from standard input (console).
+# @category System
+# @param ~hide Hide typed characters (for passwords).
+def read(~hide=false) =
+  if
+    hide
+  then
+    process.run(
+      "stty -echo"
+    )
+  end
+  s =
+    list.hd(
+      default="",
+      process.read.lines(
+        "read BLA && echo $BLA"
+      )
+    )
+  if
+    hide
+  then
+    process.run(
+      "stty echo"
+    )
+  end
+  print("")
+  s
+end

--- a/tests/liq/profiler.liq
+++ b/tests/liq/profiler.liq
@@ -1,0 +1,5 @@
+# Print profiling information.
+# @category Liquidsoap
+def profiler.print() =
+  print(profiler.stats.string())
+end

--- a/tests/liq/protocols.liq
+++ b/tests/liq/protocols.liq
@@ -1,0 +1,1139 @@
+# @flag hidden
+def settings.make.protocol(name) =
+  settings.make.void(
+    "Settings for the #{name} protocol"
+  )
+end
+
+let settings.protocol =
+  settings.make.void(
+    "Settings for registered protocols"
+  )
+
+# Register the lufs_track_gain protocol.
+# @flag hidden
+def protocol.lufs_track_gain(~rlog:_, ~maxtime:_, arg) =
+  gain = file.lufs(arg)
+  if
+    null.defined(gain)
+  then
+    "annotate:#{settings.normalize_track_gain_metadata()}=\"#{
+      settings.lufs.track_gain_target() - null.get(gain)
+    } dB\":#{arg}"
+  else
+    arg
+  end
+end
+
+protocol.add(
+  "lufs_track_gain",
+  protocol.lufs_track_gain,
+  syntax="lufs_track_gain:uri",
+  doc="Compute LUFS track gain correction and add it as metadata"
+)
+
+# Register the replaygain protocol.
+# @flag hidden
+def protocol.replaygain(~rlog:_, ~maxtime:_, arg) =
+  gain = file.replaygain(arg)
+  tag = settings.normalize_track_gain_metadata()
+  if
+    null.defined(gain)
+  then
+    "annotate:#{tag}=\"#{null.get(gain)} dB\":#{arg}"
+  else
+    arg
+  end
+end
+
+protocol.add(
+  "replaygain",
+  protocol.replaygain,
+  syntax="replaygain:uri",
+  doc="Compute ReplayGain value. Adds returned value as \
+   `\"replaygain_track_gain\"` metadata"
+)
+
+let settings.protocol.process = settings.make.protocol("process")
+let settings.protocol.process.env =
+  settings.make(
+    description="List of environment variables passed down to the executed \
+     process.",
+    []
+  )
+
+let settings.protocol.process.inherit_env =
+  settings.make(
+    description="Inherit calling process's environment when `env` parameter is \
+     empty.",
+    true
+  )
+
+let protocol.process = ()
+
+# Parse process protocol arguments
+# @flag hidden
+def protocol.process.parse(~default_timeout, arg) =
+  let [args, ...uri] = r/:/.split(arg)
+  uri = string.concat(separator=":", uri)
+  args = r/,/.split(args)
+  let args =
+    if
+      string.contains(prefix="timeout=", list.hd(args))
+    then
+      let [timeout, extname, ...cmd] = args
+      timeout = string.residual(prefix="timeout=", timeout)
+      timeout = null.map(string.to_float, timeout) ?? default_timeout
+      timeout = min(default_timeout, timeout)
+      {timeout = timeout, extname = extname, cmd = cmd}
+    else
+      let [extname, ...cmd] = args
+      {timeout = default_timeout, extname = extname, cmd = cmd}
+    end
+
+  args.{uri = uri, cmd = string.concat(separator=",", args.cmd)}
+end
+
+# Register the process protocol. Syntax:
+# process:[timeout=<seconds>],<output ext>,<cmd>:uri where `timeout` argument is optional and
+# cannot exceed the underlying time and <cmd> is interpolated with:
+# [("input",<input file>),("output",<output file>),("colon",":")]
+# See say: protocol for an example.
+# @flag hidden
+def replaces protocol.process(~rlog:_, ~maxtime, arg) =
+  log.info(
+    "Processing #{arg}"
+  )
+  let {uri, timeout, extname, cmd} =
+    protocol.process.parse(default_timeout=maxtime - time(), arg)
+
+  output = file.temp("liq-process", ".#{extname}")
+
+  def resolve(input) =
+    cmd =
+      cmd %
+        [
+          ("input", process.quote(input)),
+          ("output", process.quote(output)),
+          ("colon", ":")
+        ]
+
+    log.info(
+      "Executing #{cmd}"
+    )
+    env_vars = settings.protocol.process.env()
+    env = environment()
+
+    def get_env(k) =
+      (k, env[k])
+    end
+
+    env = list.map(get_env, env_vars)
+    inherit_env = settings.protocol.process.inherit_env()
+    p = process.run(timeout=timeout, env=env, inherit_env=inherit_env, cmd)
+    if
+      p.status == "exit" and p.status.code == 0
+    then
+      output
+    else
+      log.important(
+        "Failed to execute #{cmd}: #{p.status} (#{p.status.code})"
+      )
+      log.info(
+        "Standard output:\n#{p.stdout}"
+      )
+      log.info(
+        "Error output:\n#{p.stderr}"
+      )
+      log.info(
+        "Removing #{output}."
+      )
+      file.remove(output)
+      null
+    end
+  end
+
+  if
+    uri == ""
+  then
+    resolve("")
+  else
+    r = request.create(uri)
+    delay = maxtime - time()
+    if
+      request.resolve(timeout=delay, r)
+    then
+      res = resolve(request.filename(r))
+      request.destroy(r)
+      res
+    else
+      log(
+        level=3,
+        "Failed to resolve #{uri}"
+      )
+      null
+    end
+  end
+end
+
+protocol.add(
+  temporary=true,
+  "process",
+  protocol.process,
+  doc="Resolve a request using an arbitrary process. `<cmd>` is interpolated \
+   with: `[(\"input\",<input>),(\"output\",<output>),(\"colon\",\":\")]`. `uri` \
+   is an optional child request, `<output>` is the name of a fresh temporary \
+   file and has extension `.<extname>`. `<input>` is an optional input file name \
+   as returned while resolving `uri`.",
+  syntax="process:<extname>,<cmd>[:uri]"
+)
+
+# Create a process: uri, replacing `:` with `$(colon)`.
+# @category Liquidsoap
+# @param cmd Command line to execute
+# @param ~extname Output file extension (with no leading '.')
+# @param ~uri Input uri
+def process.uri(~timeout=null, ~extname, ~uri="", cmd) =
+  timeout = null.case(timeout, {""}, fun (t) -> "timeout=" ^ string(t) ^ ",")
+  cmd = r/:/g.replace(fun (_) -> "$(colon)", cmd)
+  uri = if uri != "" then ":#{uri}" else "" end
+  "process:#{timeout}#{extname},#{cmd}#{uri}"
+end
+
+# Resolve http(s) URLs using curl
+# @flag hidden
+def protocol.http(proto, ~rlog, ~maxtime, arg) =
+  uri = "#{proto}:#{arg}"
+
+  def log(~level, s) =
+    rlog(s)
+    log(label="procol.external", level=level, s)
+  end
+
+  timeout = maxtime - time()
+  ret = http.head(timeout=timeout, uri)
+  code = ret.status_code ?? 999
+  extname =
+    200 <= code and code < 300 ? http.headers.extname(ret.headers) : null
+
+  extname =
+    if
+      null.defined(extname)
+    then
+      null.get(extname)
+    else
+      begin
+        content_type = http.headers.content_type(ret.headers)
+        extra_log =
+          if
+            null.defined(content_type) and null.get(content_type).mime != ""
+          then
+            begin
+              content_type = null.get(content_type).mime
+              " Response has unknown mime-type: #{string.quote(content_type)} \
+               you may want to add it to `settings.http.mime.extnames` and \
+               report to us if it is a common one."
+            end
+          else
+            ""
+          end
+
+        log(
+          level=3,
+          "Failed to find a file extension for #{string.quote(uri)}.#{
+            extra_log
+          }"
+        )
+
+        ".osb"
+      end
+    end
+
+  output = file.temp("liq-process", extname)
+  file_writer = file.write.stream(output)
+  timeout = maxtime - time()
+  try
+    response = http.get.stream(on_body_data=file_writer, timeout=timeout, uri)
+    if
+      response.status_code < 400
+    then
+      output
+    else
+      log(
+        level=3,
+        "Error while fetching http data: #{response.status_code} - #{
+          response.status_message
+        }"
+      )
+
+      null
+    end
+  catch err do
+    file_writer(null)
+    log(
+      level=3,
+      "Error while fetching http data: #{err}"
+    )
+    null
+  end
+end
+
+# Register download protocol.
+# @flag hidden
+def protocol.add.http(proto) =
+  def protocol.http(~rlog, ~maxtime, arg) =
+    protocol.http(proto, rlog=rlog, maxtime=maxtime, arg)
+  end
+
+  protocol.add(
+    temporary=true,
+    syntax="#{proto}://...",
+    doc="Download http URLs using curl",
+    proto,
+    protocol.http
+  )
+end
+
+list.iter(protocol.add.http, ["http", "https"])
+let settings.protocol.youtube_dl = settings.make.protocol("youtube-dl")
+let settings.protocol.youtube_dl.path =
+  settings.make(
+    description="Path of the youtube-dl (or yt-dlp) binary.",
+    "yt-dlp"
+  )
+
+let settings.protocol.youtube_dl.timeout =
+  settings.make(
+    description="Timeout (in seconds) for youtube-dl executions.",
+    300.
+  )
+
+# Register the youtube-dl protocol, using youtube-dl.
+# Syntax: youtube-dl:<ID>
+# @flag hidden
+def protocol.youtube_dl(~rlog, ~maxtime, arg) =
+  binary = settings.protocol.youtube_dl.path()
+  timeout = settings.protocol.youtube_dl.timeout()
+
+  def log(~level, s) =
+    rlog(s)
+    log(label="protocol.youtube-dl", level=level, s)
+  end
+
+  delay = maxtime - time()
+  cmd =
+    "#{binary} --get-title --get-filename -- #{process.quote(arg)}"
+  log(
+    level=4,
+    "Executing #{cmd}"
+  )
+  x = process.read.lines(timeout=delay, cmd)
+  x = if list.length(x) >= 2 then x else ["", ".osb"] end
+  title = list.hd(default="", x)
+  ext = file.extension(leading_dot=false, list.nth(default="", x, 1))
+  cmd =
+    "#{binary} -q -f best --no-continue --no-playlist -o $(output) -- #{
+      process.quote(arg)
+    }"
+
+  cmd = process.uri(timeout=timeout, extname=ext, cmd)
+  if
+    title != ""
+  then
+    "annotate:title=#{string.quote(title)}:#{cmd}"
+  else
+    cmd
+  end
+end
+
+protocol.add(
+  "youtube-dl",
+  protocol.youtube_dl,
+  doc="Resolve a request using youtube-dl.",
+  syntax="youtube-dl:uri"
+)
+
+# Register the youtube-pl protocol.
+# Syntax: youtube-pl:<ID>
+# @flag hidden
+def protocol.youtube_pl(~rlog:_, ~maxtime, arg) =
+  binary = settings.protocol.youtube_dl.path()
+  delay = maxtime - time()
+  cmd =
+    "#{binary} -i -s --get-id --flat-playlist -- #{process.quote(arg)}"
+  log(
+    level=4,
+    "Executing #{cmd}"
+  )
+  l = process.read.lines(timeout=delay, cmd)
+  l = list.map(fun (s) -> "youtube-dl:https://www.youtube.com/watch?v=" ^ s, l)
+  l = string.concat(separator="\n", l) ^ "\n"
+  tmp = file.temp("youtube-pl", "")
+  file.write(data=l, tmp)
+  tmp
+end
+
+protocol.add(
+  "youtube-pl",
+  protocol.youtube_pl,
+  doc="Resolve a request as a youtube playlist using youtube-dl. You typically \
+   want to use this as `playlist(\"youtube-pl:...\")`.",
+  temporary=true,
+  syntax="youtube-pl:uri"
+)
+
+# Register tmp
+# @flag hidden
+def protocol.tmp(~rlog, ~maxtime, arg) =
+  r = request.create(arg)
+  delay = maxtime - time()
+  if
+    request.resolve(timeout=delay, r)
+  then
+    request.filename(r)
+  else
+    rlog(
+      "Failed to resolve #{arg}"
+    )
+    log(
+      level=3,
+      "Failed to resolve #{arg}"
+    )
+    null
+  end
+end
+
+protocol.add(
+  "tmp",
+  protocol.tmp,
+  doc="Mark the given uri as temporary. Useful when chaining protocols",
+  temporary=true,
+  syntax="tmp:uri"
+)
+
+# Register fallible
+# @flag hidden
+def protocol.fallible(~rlog:_, ~maxtime:_, arg) =
+  arg
+end
+
+protocol.add(
+  "fallible",
+  protocol.fallible,
+  doc="Mark the given uri as being fallible. This can be used to prevent a \
+   request or source from being resolved once and for all and considered \
+   infallible for the duration of the script, typically when debugging.",
+  static=fun (_) -> false,
+  syntax="fallible:uri"
+)
+
+let settings.protocol.ffmpeg = settings.make.protocol("FFmpeg")
+let settings.protocol.ffmpeg.path =
+  settings.make(
+    description="Path to the ffmpeg binary",
+    "ffmpeg"
+  )
+
+let settings.protocol.ffmpeg.metadata =
+  settings.make(
+    description="Should the protocol extract metadata",
+    true
+  )
+
+let settings.protocol.ffmpeg.replaygain =
+  settings.make(
+    description="Should the protocol adjust ReplayGain",
+    false
+  )
+
+# Register ffmpeg
+# @flag hidden
+def protocol.ffmpeg(~rlog, ~maxtime, arg) =
+  ffmpeg = settings.protocol.ffmpeg.path()
+  metadata = settings.protocol.ffmpeg.metadata()
+  replaygain = settings.protocol.ffmpeg.replaygain()
+
+  def log(~level, s) =
+    rlog(s)
+    log(label="protocol.ffmpeg", level=level, s)
+  end
+
+  def annotate(m) =
+    def f(x) =
+      let (key, value) = x
+      "#{key}=#{string.quote(value)}"
+    end
+
+    m = string.concat(separator=",", list.map(f, m))
+    if string.bytes.length(m) > 0 then "annotate:#{m}:" else "" end
+  end
+
+  def parse_metadata(file) =
+    cmd =
+      "#{ffmpeg} -i #{process.quote(file)} -f ffmetadata - 2>/dev/null | grep -v \
+       '^;'"
+
+    delay = maxtime - time()
+    log(
+      level=4,
+      "Executing #{cmd}"
+    )
+    lines = process.read.lines(timeout=delay, cmd)
+
+    def f(cur, line) =
+      m = r/=/.split(line)
+      if
+        list.length(m) >= 2
+      then
+        key = list.hd(default="", m)
+        value = string.concat(separator="=", list.tl(m))
+        (key, value)::cur
+      else
+        cur
+      end
+    end
+
+    list.fold(f, [], lines)
+  end
+
+  def replaygain_filter(fname) =
+    if
+      replaygain
+    then
+      gain = file.replaygain(fname)
+      if
+        null.defined(gain)
+      then
+        "-af \"volume=#{null.get(gain)} dB\""
+      else
+        ""
+      end
+    else
+      ""
+    end
+  end
+
+  def cue_points(m) =
+    cue_in =
+      float_of_string(default=0., list.assoc(default="0.", "liq_cue_in", m))
+
+    cue_out =
+      float_of_string(default=0., list.assoc(default="", "liq_cue_out", m))
+
+    args =
+      if
+        cue_in > 0.
+      then
+        "-ss #{cue_in}"
+      else
+        ""
+      end
+    if
+      cue_out > cue_in
+    then
+      "#{args} -t #{cue_out - cue_in}"
+    else
+      args
+    end
+  end
+
+  def fades(r) =
+    m = request.metadata(r)
+    fade_type = list.assoc(default="", "liq_fade_type", m)
+    fade_in = list.assoc(default="", "liq_fade_in", m)
+    cue_in = list.assoc(default="", "liq_cue_in", m)
+    fade_out = list.assoc(default="", "liq_fade_out", m)
+    cue_out = list.assoc(default="", "liq_cue_out", m)
+    curve =
+      if
+        fade_type == "lin"
+      then
+        ":curve=tri"
+      elsif
+        fade_type == "sin"
+      then
+        ":curve=qsin"
+      elsif
+        fade_type == "log"
+      then
+        ":curve=log"
+      elsif
+        fade_type == "exp"
+      then
+        ":curve=exp"
+      else
+        ""
+      end
+
+    args =
+      if
+        fade_in != ""
+      then
+        fade_in = float_of_string(default=0., fade_in)
+        start_time =
+          if cue_in != "" then float_of_string(default=0., cue_in) else 0. end
+
+        if
+          fade_in > 0.
+        then
+          ["afade=in:st=#{start_time}:d=#{fade_in}#{curve}"]
+        else
+          []
+        end
+      else
+        []
+      end
+
+    args =
+      if
+        fade_out != ""
+      then
+        fade_out = float_of_string(default=0., fade_out)
+        end_time =
+          if
+            cue_out != ""
+          then
+            float_of_string(default=0., cue_out)
+          else
+            null.get(request.duration(request.filename(r)))
+          end
+
+        if
+          fade_out > 0.
+        then
+          list.append(
+            args,
+            ["afade=out:st=#{end_time - fade_out}:d=#{fade_out}#{curve}"]
+          )
+        else
+          args
+        end
+      else
+        args
+      end
+
+    if
+      list.length(args) > 0
+    then
+      args = string.concat(separator=",", args)
+      "-af #{args}"
+    else
+      ""
+    end
+  end
+
+  r = request.create(arg)
+  delay = maxtime - time()
+  if
+    request.resolve(timeout=delay, r)
+  then
+    filename = request.filename(r)
+    m = request.metadata(r)
+    m = if metadata then list.append(m, parse_metadata(filename)) else m end
+    annotate = annotate(m)
+    request.destroy(r)
+
+    # Now parse the audio
+    wav = file.temp("liq-process", ".wav")
+    cue_points = cue_points(request.metadata(r))
+    fades = fades(r)
+    replaygain_filter = replaygain_filter(filename)
+    cmd =
+      "#{ffmpeg} -y -i $(input) #{cue_points} #{fades} #{replaygain_filter} #{
+        process.quote(wav)
+      }"
+
+    uri = process.uri(extname="wav", uri=filename, cmd)
+    wav_r = request.create(uri)
+    delay = maxtime - time()
+    if
+      request.resolve(timeout=delay, wav_r)
+    then
+      request.destroy(wav_r)
+      "#{annotate}tmp:#{wav}"
+    else
+      log(
+        level=3,
+        "Failed to resolve #{uri}"
+      )
+      null
+    end
+  else
+    log(
+      level=3,
+      "Failed to resolve #{arg}"
+    )
+    null
+  end
+end
+
+protocol.add(
+  "ffmpeg",
+  protocol.ffmpeg,
+  doc="Decode any file to wave using ffmpeg",
+  syntax="ffmpeg:uri"
+)
+
+# Register stereo protocol which converts a file to stereo (currently decodes as
+# wav).
+# @flag hidden
+def protocol.stereo(~rlog:_, ~maxtime:_, arg) =
+  file = file.temp("liq-stereo", ".wav")
+  r = request.create(arg)
+  if
+    not request.resolve(r)
+  then
+    log.info(
+      "Stereo: failed to resolve request #{arg}"
+    )
+    null
+  else
+    request.dump(%wav, file, request.create(arg))
+    file
+  end
+end
+
+protocol.add(
+  static=fun (_) -> true,
+  temporary=true,
+  "stereo",
+  protocol.stereo,
+  doc="Convert a file to stereo (currently decodes to wav).",
+  syntax="stereo:<uri>"
+)
+
+# Copy
+
+# @flag hidden
+def protocol.copy(~rlog:_, ~maxtime:_, arg) =
+  extname = file.extension(arg)
+  tmpfile = file.temp("tmp", extname)
+  file.copy(force=true, arg, tmpfile)
+  tmpfile
+end
+
+protocol.add(
+  static=fun (_) -> true,
+  "copy",
+  protocol.copy,
+  doc="Copy file to a temporary destination",
+  syntax="copy:/path/to/file.extname"
+)
+
+# Text2wave
+# @category Settings
+let settings.protocol.text2wave = settings.make.protocol("text2wave")
+let settings.protocol.text2wave.path =
+  settings.make(
+    description="Path to the text2wave binary",
+    "text2wave"
+  )
+
+# Register the text2wave: protocol using text2wave
+# @flag hidden
+def protocol.text2wave(~rlog:_, ~maxtime:_, arg) =
+  binary = settings.protocol.text2wave.path()
+  process.uri(
+    extname="wav",
+    "echo #{process.quote(arg)} | #{binary} -scale 1.9 > $(output)"
+  )
+end
+
+protocol.add(
+  static=fun (_) -> true,
+  "text2wave",
+  protocol.text2wave,
+  doc="Generate speech synthesis using text2wave. Result may be mono.",
+  syntax="text2wave:Text to read"
+)
+
+# Pico2wave
+# @category Settings
+let settings.protocol.pico2wave = settings.make.protocol("pico2wave")
+let settings.protocol.pico2wave.path =
+  settings.make(
+    description="Path to the pico2wave binary",
+    "pico2wave"
+  )
+
+let settings.protocol.pico2wave.lang =
+  settings.make(
+    description="pico2wave language. One of: `\"en-US\"`, `\"en-GB\"`, \
+     `\"es-ES\"`, `\"de-DE\"`, `\"fr-FR\"` or `\"it-IT\"`.",
+    "en-US"
+  )
+
+# @flag hidden
+def protocol.pico2wave(~rlog:_, ~maxtime:_, arg) =
+  binary = settings.protocol.pico2wave.path()
+  lang = settings.protocol.pico2wave.lang()
+  process.uri(
+    extname="wav",
+    "#{binary} -l #{lang} -w $(output) #{process.quote(arg)}"
+  )
+end
+
+protocol.add(
+  static=fun (_) -> true,
+  "pico2wave",
+  protocol.pico2wave,
+  doc="Generate speech synthesis using pico2wave. Result may be mono.",
+  syntax="pico2wave:Text to read"
+)
+
+# GTTS
+# @category Settings
+let settings.protocol.gtts = settings.make.protocol("gtts")
+let settings.protocol.gtts.path =
+  settings.make(
+    description="Path to the gtts binary",
+    "gtts-cli"
+  )
+
+let settings.protocol.gtts.lang =
+  settings.make(
+    description="Language to speak in.",
+    "en"
+  )
+
+let settings.protocol.gtts.options =
+  settings.make(
+    description="Command line options.",
+    ""
+  )
+
+# Register the gtts: protocol using gtts
+# @flag hidden
+def protocol.gtts(~rlog:_, ~maxtime:_, arg) =
+  binary = settings.protocol.gtts.path()
+  lang = settings.protocol.gtts.lang()
+  options = settings.protocol.gtts.options()
+  process.uri(
+    extname="mp3",
+    "#{binary} --lang #{lang} #{options} -o $(output) #{process.quote(arg)}"
+  )
+end
+
+protocol.add(
+  static=fun (_) -> true,
+  "gtts",
+  protocol.gtts,
+  doc="Generate speech synthesis using Google translate's text-to-speech API. \
+   This requires the `gtts-cli` binary.  Result may be mono.",
+  syntax="gtts:Text to read"
+)
+
+# MacOS say
+# @category Settings
+let settings.protocol.macos_say = settings.make.protocol("macos_say")
+let settings.protocol.macos_say.path =
+  settings.make(
+    description="Path to the say binary",
+    "say"
+  )
+
+let settings.protocol.macos_say.options =
+  settings.make(
+    description="Command line options.",
+    ""
+  )
+
+# Register the macos_say: protocol using the say command available on macos
+# @flag hidden
+def protocol.macos_say(~rlog:_, ~maxtime:_, arg) =
+  binary = settings.protocol.macos_say.path()
+  options = settings.protocol.macos_say.options()
+  process.uri(
+    extname="aiff",
+    "#{binary} #{options} -o $(output) #{process.quote(arg)}"
+  )
+end
+
+protocol.add(
+  static=fun (_) -> true,
+  "macos_say",
+  protocol.macos_say,
+  doc="Generate speech synthesis using the `say` command available on macos.",
+  syntax="macos_say:Text to read"
+)
+
+# Say
+# @category Settings
+let settings.protocol.say = settings.make.protocol("say")
+let settings.protocol.say.implementation =
+  settings.make(
+    description="Implementation to use. One of: \"pico2wave\", \"gtts\", \
+     \"text2wave\" or \"macos_say\".",
+    liquidsoap.build_config.system == "macosx" ? "macos_say" : "pico2wave"
+  )
+
+# Register the legacy say: protocol
+# @flag hidden
+def protocol.say(~rlog:_, ~maxtime:_, arg) =
+  "#{settings.protocol.say.implementation()}:#{arg}"
+end
+
+protocol.add(
+  static=fun (_) -> true,
+  "say",
+  protocol.say,
+  doc="Generate speech synthesis using text2wave. Result is always stereo.",
+  syntax="say:Text to read"
+)
+
+let settings.protocol.aws = settings.make.protocol("AWS")
+let settings.protocol.aws.profile =
+  settings.make(
+    description="Use a specific profile from your credential file.",
+    null
+  )
+
+let settings.protocol.aws.endpoint =
+  settings.make(
+    description="Alternative endpoint URL (useful for other S3 \
+     implementations).",
+    null
+  )
+
+let settings.protocol.aws.region =
+  settings.make(
+    description="AWS Region",
+    null
+  )
+
+let settings.protocol.aws.path =
+  settings.make(
+    description="Path to aws CLI binary",
+    "aws"
+  )
+
+let settings.protocol.aws.polly = settings.make.protocol("polly")
+let settings.protocol.aws.polly.format =
+  settings.make(
+    description="Output format",
+    "mp3"
+  )
+
+let settings.protocol.aws.polly.voice =
+  settings.make(
+    description="Voice ID",
+    "Joanna"
+  )
+
+let settings.protocol.aws.polly.extra_args =
+  settings.make(
+    description="Extra command line arguments",
+    ([] : [string])
+  )
+
+# Build a aws base call
+# @flag hidden
+def aws_base() =
+  aws = settings.protocol.aws.path()
+  region = settings.protocol.aws.region()
+  aws =
+    if
+      null.defined(region)
+    then
+      "#{aws} --region #{null.get(region)}"
+    else
+      aws
+    end
+
+  endpoint = settings.protocol.aws.endpoint()
+  aws =
+    if
+      null.defined(endpoint)
+    then
+      "#{aws} --endpoint-url #{process.quote(null.get(endpoint))}"
+    else
+      aws
+    end
+
+  profile = settings.protocol.aws.profile()
+  if
+    null.defined(profile)
+  then
+    "#{aws} --profile #{process.quote(null.get(profile))}"
+  else
+    aws
+  end
+end
+
+# Register the s3:// protocol
+# @flag hidden
+def s3_protocol(~rlog:_, ~maxtime:_, arg) =
+  extname = file.extension(leading_dot=false, dir_sep="/", arg)
+  arg = process.quote("s3:#{arg}")
+  process.uri(
+    extname=extname,
+    "#{aws_base()} s3 cp #{arg} $(output)"
+  )
+end
+
+protocol.add(
+  "s3",
+  s3_protocol,
+  doc="Fetch files from s3 using the AWS CLI",
+  syntax="s3://uri"
+)
+
+# Register the polly: protocol using AWS Polly
+# speech synthesis services. Syntax: polly:<text>
+# @flag hidden
+def polly_protocol(~rlog:_, ~maxtime:_, text) =
+  aws = aws_base()
+  format = settings.protocol.aws.polly.format()
+  extname =
+    if
+      format == "mp3"
+    then
+      "mp3"
+    elsif
+      format == "ogg_vorbis"
+    then
+      "ogg"
+    else
+      "wav"
+    end
+
+  aws =
+    "#{aws} polly synthesize-speech --output-format #{format}"
+  voice_id = settings.protocol.aws.polly.voice()
+  extra_args =
+    string.concat(
+      separator=" ",
+      settings.protocol.aws.polly.extra_args()
+    )
+  cmd =
+    "#{aws} --text #{process.quote(text)} --voice-id #{
+      process.quote(voice_id)
+    } #{extra_args} $(output)"
+
+  process.uri(extname=extname, cmd)
+end
+
+protocol.add(
+  static=fun (_) -> true,
+  "polly",
+  polly_protocol,
+  doc="Generate speech synthesis using AWS polly service. Result might be mono, \
+   needs aws binary in the path.",
+  syntax="polly:Text to read"
+)
+
+# Protocol to synthesize audio.
+# @flag hidden
+def synth_protocol(~rlog:_, ~maxtime:_, text) =
+  log.debug(
+    label="synth",
+    "Synthesizing request: #{text}"
+  )
+  args = r/,/.split(text)
+  args = list.map(r/=/.split, args)
+  if
+    list.exists(fun (l) -> list.length(l) != 2, args)
+  then
+    null
+  else
+    args =
+      list.map(
+        fun (l) -> (list.hd(default="", l), list.hd(default="", list.tl(l))),
+        args
+      )
+
+    shape = ref("sine")
+    duration = ref(10.)
+    frequency = ref(440.)
+
+    def set(p) =
+      let (k, v) = p
+      if
+        k == "d" or k == "duration"
+      then
+        duration := float_of_string(v)
+      elsif
+        k == "f" or k == "freq" or k == "frequency"
+      then
+        frequency := float_of_string(v)
+      elsif
+        k == "s" or k == "shape"
+      then
+        shape := v
+      end
+    end
+
+    list.iter(set, args)
+
+    def synth(s) =
+      file = file.temp("liq-synth", ".wav")
+      log.info(
+        label="synth",
+        "Synthesizing #{shape()} in #{file}."
+      )
+
+      clock.assign_new(sync="passive", [s])
+
+      stopped = ref(false)
+      o = output.file(fallible=true, %wav, file, once(s))
+      o.on_stop(synchronous=true, {stopped.set(true)})
+
+      c = clock(s.clock)
+      c.start()
+      while not stopped() do c.tick()  end
+      c.stop()
+
+      file
+    end
+
+    if
+      shape() == "sine"
+    then
+      synth(sine(duration=duration(), frequency()))
+    elsif
+      shape() == "saw"
+    then
+      synth(saw(duration=duration(), frequency()))
+    elsif
+      shape() == "square"
+    then
+      synth(square(duration=duration(), frequency()))
+    elsif
+      shape() == "blank"
+    then
+      synth(blank(duration=duration()))
+    else
+      null
+    end
+  end
+end
+
+protocol.add(
+  static=fun (_) -> true,
+  temporary=true,
+  "synth",
+  synth_protocol,
+  doc="Synthesize audio. Parameters are optional.",
+  syntax="synth:shape=sine,frequency=440.,duration=10."
+)
+
+# File protocol
+# @flag hidden
+def file_protocol(~rlog:_, ~maxtime:_, arg) =
+  if
+    not r/^file:/.test(arg)
+  then
+    null
+  else
+    url.decode(r/^file:(?:\/\/)?/.replace(fun (_) -> "", arg))
+  end
+end
+
+protocol.add(
+  static=fun (_) -> true,
+  temporary=false,
+  "file",
+  file_protocol,
+  doc="File protocol. Only local files are supported",
+  syntax="file:///path/to/file"
+)

--- a/tests/liq/ref.liq
+++ b/tests/liq/ref.liq
@@ -1,0 +1,28 @@
+# Create a reference from a pair of get / set functions.
+# @category Programming
+# @param get Function to retrieve the value of the reference.
+# @param set Function to change the value of the reference.
+def ref.make(get, set) =
+  (get.{set = set} : ref)
+end
+
+# Create a getter from a reference (sometimes useful to remove the `set`
+# method).
+# @category Programming
+def ref.getter((r:ref)) =
+  {r()}
+end
+
+# Map functions to a reference.
+# @category Programming
+# @param g Function to apply to the getter.
+# @param s Function to apply to the setter.
+def ref.map(g, s, (r:ref)) =
+  ref.make({g(r())}, fun (x) -> r.set(s(x)))
+end
+
+# Increment a reference to an integer.
+# @category Programming
+def ref.incr(r) =
+  r := r() + 1
+end

--- a/tests/liq/replaygain.liq
+++ b/tests/liq/replaygain.liq
@@ -1,0 +1,135 @@
+let file.replaygain = ()
+
+# Compute the ReplayGain for a file (in dB).
+# @category File
+# @param ~id Force the value of the source ID.
+# @param ~ratio Decoding ratio. A value of `50` means try to decode the file `50x` faster than real time, if possible.
+#               Use this setting to lower CPU peaks when computing replaygain tags.
+# @param file_name File name.
+# @flag hidden
+def file.replaygain.compute(~ratio=50., file_name) =
+  _request = request.create(resolve_metadata=false, file_name)
+  if
+    request.resolve(_request)
+  then
+    get_gain = ref(fun () -> null)
+    def process(s) =
+      s = source.replaygain.compute(s)
+      get_gain := {s.gain()}
+      s
+    end
+
+    request.process(ratio=ratio, process=process, _request)
+
+    fn = get_gain()
+    fn()
+  else
+    null
+  end
+end
+
+# Extract the ReplayGain from the metadata (in dB).
+# @category Metadata
+# @param _metadata Metadata from which the ReplayGain should be extracted.
+def metadata.replaygain(_metadata) =
+  if
+    list.assoc.mem("r128_track_gain", _metadata)
+  then
+    try
+      float_of_string(_metadata["r128_track_gain"]) / 256.
+    catch _ do
+      null
+    end
+  elsif
+    list.assoc.mem("replaygain_track_gain", _metadata)
+  then
+    replaygain_metadata = _metadata["replaygain_track_gain"]
+    match = r/([+-]?\d*\.?\d*)/.exec(replaygain_metadata)
+    try
+      float_of_string(list.assoc(1, match))
+    catch _ do
+      null
+    end
+  else
+    null
+  end
+end
+
+# Get the ReplayGain for a file (in dB).
+# @category File
+# @param ~id Force the value of the source ID.
+# @param ~compute Compute ReplayGain if metadata tag is empty.
+# @param ~ratio Decoding ratio. A value of `50` means try to decode the file `50x` faster than real time, if possible.
+#               Use this setting to lower CPU peaks when computing replaygain tags.
+# @param file_name File name.
+def replaces file.replaygain(~id=null, ~compute=true, ~ratio=50., file_name) =
+  id = string.id.default(default="file.replaygain", id)
+  file_name_quoted = string.quote(file_name)
+
+  _metadata = file.metadata(exclude=decoder.metadata.reentrant(), file_name)
+  gain = metadata.replaygain(_metadata)
+
+  if
+    gain != null
+  then
+    log.info(
+      label=id,
+      "Detected track replaygain #{gain} dB for #{file_name_quoted}."
+    )
+    gain
+  elsif
+    compute
+  then
+    log.info(
+      label=id,
+      "Computing replay gain for #{file_name_quoted}."
+    )
+    start_time = time()
+    gain = file.replaygain.compute(ratio=ratio, file_name)
+    elapsed_time = time() - start_time
+    if
+      gain != null
+    then
+      log.info(
+        label=id,
+        "Computed replay gain #{gain} dB for #{file_name_quoted} (time: #{
+          elapsed_time
+        } s)."
+      )
+    end
+    gain
+  else
+    null
+  end
+end
+
+# Enable ReplayGain metadata resolver. This resolver will process any file
+# decoded by Liquidsoap and add a `replaygain_track_gain` metadata when this
+# value could be computed. For a finer-grained replay gain processing, use the
+# `replaygain:` protocol.
+# @param ~compute Compute replaygain if metadata tag is empty.
+# @param ~ratio Decoding ratio. A value of `50.` means try to decode the file `50x` faster than real time, if possible. Use this setting to lower CPU peaks when computing replaygain tags.
+# @category Liquidsoap
+def enable_replaygain_metadata(~compute=true, ~ratio=50.) =
+  def replaygain_metadata(~metadata:_, file_name) =
+    gain = file.replaygain(compute=compute, ratio=ratio, file_name)
+    if
+      gain != null
+    then
+      [
+        (
+          settings.normalize_track_gain_metadata(),
+          "#{null.get(gain)} dB"
+        )
+      ]
+    else
+      []
+    end
+  end
+
+  decoder.metadata.add(
+    reentrant=true,
+    "replaygain_track_gain",
+    replaygain_metadata
+  )
+end

--- a/tests/liq/request.liq
+++ b/tests/liq/request.liq
@@ -1,0 +1,467 @@
+%ifdef native
+let stdlib_native = native
+%endif
+
+# @docof request.dynamic
+# @param ~native Use native implementation, when available.
+def replaces request.dynamic(%argsof(request.dynamic), ~native=false, f) =
+  ignore(native)
+  default = request.dynamic(%argsof(request.dynamic), f)
+%ifdef native
+  if
+    native
+  then
+    stdlib_native.request.dynamic(%argsof(request.dynamic), f)
+  else
+    default
+  end
+%else
+  default
+%endif
+end
+
+# Play a queue of requests (the first added request gets played first).
+# @category Source / Track processing
+# @param ~id Force the value of the source ID.
+# @param ~interactive Should the queue be controllable via telnet?
+# @param ~prefetch How many requests should be queued in advance.
+# @param ~native Use native implementation, when available.
+# @param ~queue Initial queue of requests.
+# @param ~timeout Timeout (in sec.) to resolve the request.
+# @method add This method is internal and should not be used. Consider using `push` instead.
+# @method push Push a request on the request queue.
+# @method length Length of the queue.
+def request.queue(
+  ~id=null,
+  ~interactive=true,
+  ~prefetch=null,
+  ~native=false,
+  ~queue=[],
+  ~timeout=null
+) =
+  ignore(native)
+  id = string.id.default(default="request.queue", id)
+  initial_queue = ref(queue)
+  queue = ref([])
+  fetch = ref(fun () -> ())
+  started = ref(false)
+
+  def next() =
+    if
+      queue() != []
+    then
+      let [r, ...q] = queue()
+      queue := q
+      (r : request)
+    else
+      null
+    end
+  end
+
+  def push(r) =
+    if
+      started()
+    then
+      log.info(
+        label=id,
+        "Pushing #{r} on the queue."
+      )
+      queue := [...queue(), r]
+      fn = fetch()
+      fn()
+    else
+      log.info(
+        label=id,
+        "Pushing #{r} on the initial queue."
+      )
+      initial_queue := [...initial_queue(), r]
+    end
+  end
+
+  def push_uri(uri) =
+    r = request.create(uri)
+    push(r)
+  end
+
+  default =
+    fun () ->
+      request.dynamic(
+        id=id,
+        prefetch=prefetch,
+        timeout=timeout,
+        available={not list.is_empty(queue())},
+        next
+      )
+
+  s =
+%ifdef native
+    if
+      native
+    then
+      stdlib_native.request.dynamic(id=id, timeout=timeout, next)
+    else
+      default()
+    end
+%else
+    default()
+%endif
+
+  def add(r) =
+    log.severe(
+      label=s.id(),
+      "Please use #{s.id()}.push instead of #{s.id()}.add()"
+    )
+
+    s.add(r)
+  end
+
+  def set_queue(q) =
+    if started() then queue := q else initial_queue := q end
+    s.set_queue([])
+  end
+
+  def get_queue() =
+    [...s.queue(), ...initial_queue(), ...queue()]
+  end
+
+  s =
+    s.{
+      add = add,
+      push = push.{uri = push_uri},
+      length = {list.length(queue()) + list.length(s.queue())},
+      set_queue = set_queue,
+      queue = get_queue
+    }
+
+  s.on_wake_up(
+    synchronous=true,
+    fun () ->
+      begin
+        started := true
+        s.set_queue(initial_queue())
+        initial_queue := []
+      end
+  )
+
+  fetch := s.fetch
+
+  if
+    interactive
+  then
+    def push(uri) =
+      r = request.create(uri)
+      push(r)
+      "#{request.id(r)}"
+    end
+
+    s.register_command(
+      description="Flush the queue and skip the current track",
+      "flush_and_skip",
+      fun (_) ->
+        try
+          s.set_queue([])
+          s.skip()
+          "Done."
+        catch err do
+          "Error while flushing and skipping source: #{err}"
+        end
+    )
+
+    s.register_command(
+      description="Push a new request in the queue.",
+      usage="push <uri>",
+      "push",
+      push
+    )
+
+    def show_queue(_) =
+      queue = s.queue()
+      string.concat(
+        separator=" ",
+        list.map(fun (r) -> string(request.id(r)), queue)
+      )
+    end
+
+    s.register_command(
+      description="Display current queue content.",
+      usage="queue",
+      "queue",
+      show_queue
+    )
+
+    def skip(_) =
+      s.skip()
+      "Done."
+    end
+
+    s.register_command(
+      description="Skip current song.",
+      usage="skip",
+      "skip",
+      skip
+    )
+  end
+
+  s
+end
+
+# Play a request once and become unavailable.
+# @category Source / Input / Passive
+# @param ~timeout Timeout in seconds for resolving the request.
+# @param r Request to play.
+def request.once(~id=null("request.once"), ~timeout=null, r) =
+  id = string.id.default(default="request.once", id)
+
+  done = ref(false)
+  fail = fallback([])
+
+  def next() =
+    if
+      done()
+    then
+      null
+    else
+      done := true
+      if
+        request.resolve(r, timeout=timeout)
+      then
+        request.queue(queue=[r])
+      else
+        log.critical(
+          label=id,
+          "Failed to prepare track: request not ready."
+        )
+        request.destroy(r)
+        fail
+      end
+    end
+  end
+
+  s = source.dynamic(self_sync=false, track_sensitive=true, next)
+  (s : source_methods).{
+    resolve = fun () -> request.resolve(r, timeout=timeout),
+    request = r
+  }
+end
+
+# Loop on a request. It never fails if the request is static, meaning
+# that it can be fetched once. Typically, http, ftp, say requests are
+# static, and time is not.
+# @category Source / Input / Passive
+# @param ~prefetch How many requests should be queued in advance.
+# @param ~timeout Timeout (in sec.) to resolve the request.
+# @param ~fallible Enforce fallibility of the request.
+# @param r Request
+def request.single(
+  ~id=null("request.single"),
+  ~prefetch=null,
+  ~timeout=null,
+  ~fallible=null,
+  r
+) =
+  id = string.id.default(default="single", id)
+
+  fallible = fallible ?? not getter.is_constant(r)
+
+  infallible =
+    if
+      not fallible
+    then
+      if
+        not getter.is_constant(r)
+      then
+        error.raise(
+          error.invalid,
+          "Infallible sources cannot change their underlying file."
+        )
+      end
+
+      initial_request = getter.get(r)
+      uri = request.uri(initial_request)
+      request.is_static(uri)
+    else
+      false
+    end
+
+  if
+    not fallible and not infallible
+  then
+    log.severe(
+      label=id,
+      "Source was marked a infallible but its request is not a static file. The \
+       source is considered fallible for backward compatibility but this will \
+       fail in future versions!"
+    )
+  end
+
+  static_request = ref(null)
+
+  def on_wake_up(s) =
+    if
+      infallible
+    then
+      initial_request = getter.get(r)
+      uri = request.uri(initial_request)
+
+      log.important(
+        label=id,
+        "#{uri} is static, resolving once for all..."
+      )
+
+      if
+        not request.resolve(initial_request, timeout=timeout, content_type=s)
+      then
+        request.destroy(initial_request)
+        error.raise(
+          error.invalid,
+          "Could not resolve uri: #{uri}"
+        )
+      else
+        static_request := initial_request
+      end
+    end
+  end
+
+  def on_shutdown() =
+    if
+      null.defined(static_request())
+    then
+      request.destroy(null.get(static_request()))
+    end
+    static_request := null
+  end
+
+  def next() =
+    static_request() ?? getter.get(r)
+  end
+
+  def mk_source(id) =
+    request.dynamic(id=id, prefetch=prefetch, synchronous=infallible, next)
+  end
+
+  # We want to mark infallible source as such. `source.dynamic` is a nice
+  # way to do it as it will raise a user-friendly error in case the underlying
+  # source does not respect the conditions for being infallible.
+  s =
+    if
+      infallible
+    then
+      s = mk_source("#{id}.actual")
+      source.dynamic(
+        id=id,
+        infallible=infallible,
+        self_sync=false,
+        track_sensitive=true,
+        {s}
+      )
+    else
+      mk_source(id)
+    end
+
+  s.on_wake_up(synchronous=true, fun () -> on_wake_up(s))
+  s.on_shutdown(synchronous=true, on_shutdown)
+  (s : source_methods)
+end
+
+# Loop on a URI. It never fails if the request is static, meaning
+# that it can be fetched once. Typically, http, ftp, say requests are
+# static, and time is not.
+# @category Source / Input / Passive
+# @param ~prefetch How many requests should be queued in advance.
+# @param ~timeout Timeout (in sec.) to resolve the request.
+# @param ~fallible Enforce fallibility of the request.
+# @param ~cue_in_metadata Metadata for cue in points. Disabled if `null`.
+# @param ~cue_out_metadata Metadata for cue out points. Disabled if `null`.
+# @param uri URI where to find the file
+def single(
+  %argsof(request.single[!id,!fallible]),
+  ~id=null("single"),
+  ~fallible=false,
+  ~cue_in_metadata=null("liq_cue_in"),
+  ~cue_out_metadata=null("liq_cue_out"),
+  uri
+) =
+  r =
+    if
+      fallible
+    then
+      getter(
+        {
+          request.create(
+            cue_in_metadata=cue_in_metadata,
+            cue_out_metadata=cue_out_metadata,
+            uri
+          )
+        }
+      )
+    else
+      request.create(
+        persistent=true,
+        cue_in_metadata=cue_in_metadata,
+        cue_out_metadata=cue_out_metadata,
+        uri
+      )
+    end
+
+  request.single(%argsof(request.single), r)
+end
+
+# Create a source on which plays immediately requests given with the `play`
+# method.
+# @category Source / Track processing
+# @param ~simultaneous Allow multiple requests to play simultaneously. If `false` a new request replaces the previous one.
+# @method play Play a request.
+# @method length Number of currently playing requests.
+def request.player(~simultaneous=true) =
+  if
+    simultaneous
+  then
+    l = ref([])
+    s = ref(add(normalize=false, l()))
+
+    # Perform some garbage collection in order to avoid that the list grows too
+    # much.
+    def collect(~reload_source) =
+      len = list.length(l())
+      l := list.filter(source.is_ready, l())
+      if
+        reload_source and list.length(l()) != len
+      then
+        s := add(normalize=false, l())
+      end
+    end
+
+    def play(r) =
+      collect(reload_source=false)
+      l := [request.once(r), ...l()]
+      s := add(normalize=false, l())
+    end
+
+    source.dynamic(s).{
+      play = play,
+      length =
+        {
+          collect(reload_source=true)
+          list.length(l())
+        }
+    }
+  else
+    next_source = ref(null)
+
+    def next() =
+      s = next_source()
+      next_source := null
+      s
+    end
+
+    s = source.dynamic(next)
+
+    def play(r) =
+      r = request.once(r)
+      r = s.prepare(r)
+      next_source := r
+    end
+
+    s.{play = play, length = {1}}
+  end
+end

--- a/tests/liq/resolvers.liq
+++ b/tests/liq/resolvers.liq
@@ -1,0 +1,33 @@
+# @flag hidden
+def youtube_playlist_parser(~pwd="", url) =
+  ignore(pwd)
+  binary = null.get(settings.protocol.youtube_dl.path())
+
+  def parse_line(line) =
+    let json.parse (parsed : {url: string}?) = line
+    parsed = parsed ?? {url = "foo"}
+    url = parsed.url
+    ([], "youtube-dl:#{url}")
+  end
+
+  if
+    r/^youtube-pl/.test(url)
+  then
+    uri = list.nth(default="", r/:/.split(url), 1)
+    list.map(
+      parse_line,
+      process.read.lines(
+        "#{binary} -j --flat-playlist #{uri}"
+      )
+    )
+  else
+    []
+  end
+end
+
+playlist.parse.register(
+  name="youtube-dl",
+  mimes=[],
+  strict=true,
+  youtube_playlist_parser
+)

--- a/tests/liq/runtime.liq
+++ b/tests/liq/runtime.liq
@@ -1,0 +1,70 @@
+# @docof runtime.memory
+def replaces runtime.memory() =
+  x =
+    {
+      ...runtime.memory(),
+      process_managed_memory =
+        runtime.gc.quick_stat().heap_words * runtime.sys.word_size / 8
+    }
+
+  let x.pretty =
+    {
+      process_managed_memory =
+        runtime.memory.prettify_bytes(x.process_managed_memory),
+      total_virtual_memory =
+        runtime.memory.prettify_bytes(x.total_virtual_memory),
+      total_physical_memory =
+        runtime.memory.prettify_bytes(x.total_physical_memory),
+      total_used_virtual_memory =
+        runtime.memory.prettify_bytes(x.total_used_virtual_memory),
+      total_used_physical_memory =
+        runtime.memory.prettify_bytes(x.total_used_physical_memory),
+      process_virtual_memory =
+        runtime.memory.prettify_bytes(x.process_virtual_memory),
+      process_physical_memory =
+        runtime.memory.prettify_bytes(x.process_physical_memory),
+      process_private_memory =
+        runtime.memory.prettify_bytes(x.process_private_memory),
+      process_swapped_memory =
+        runtime.memory.prettify_bytes(x.process_swapped_memory)
+    }
+
+  x
+end
+
+let runtime.cpu = ()
+%ifdef process.time
+# Create a function returning CPU usage (in `float` percent so
+# `0.2` means `20%`) since the last time it was called.
+# @category Liquidsoap
+def runtime.cpu.usage_getter() =
+  t = ref(time())
+  let {user, system} = process.time()
+  u = ref(user)
+  s = ref(system)
+
+  def f() =
+    t' = time()
+    delta = t' - t()
+    let {user, system} = process.time()
+    u' = user - u()
+    s' = system - s()
+    t := t'
+    u := user
+    s := system
+    {user = u' / delta, system = s' / delta, total = (u' + s') / delta}
+  end
+
+  f
+end
+%endif
+
+# Set the current time zone. This is
+# equivalent to setting the `TZ` environment
+# variable.
+# @category Time
+def time.zone.set(tz) =
+  environment.set("TZ", tz)
+end
+
+runtime.gc.set(runtime.gc.get().{space_overhead = 80})

--- a/tests/liq/server.liq
+++ b/tests/liq/server.liq
@@ -1,0 +1,99 @@
+# Enable telnet server.
+# @category Interaction
+# @param ~port Port on which we should listen.
+def server.telnet(~port=1234) =
+  settings.server.telnet.port := port
+  settings.server.telnet := true
+end
+
+server.register(
+  namespace="runtime.gc",
+  description="Run a full memory collection",
+  "full_major",
+  fun (_) ->
+    begin
+      runtime.gc.full_major()
+      "Done!"
+    end
+)
+
+server.register(
+  namespace="runtime.gc",
+  description="Compact OCaml memory",
+  "compact",
+  fun (_) ->
+    begin
+      runtime.gc.compact()
+      "Done!"
+    end
+)
+
+server.register(
+  namespace="runtime",
+  description="Return a description of the memory used by the process",
+  "memory",
+  fun (_) ->
+    begin
+      let {
+        process_managed_memory,
+        process_physical_memory,
+        process_private_memory,
+        process_swapped_memory
+      } = runtime.memory().pretty
+      "Physical memory: #{process_physical_memory}\nPrivate memory: #{
+        process_private_memory
+      }\nManaged memory: #{process_managed_memory}\nSwapped memory: #{
+        process_swapped_memory
+      }"
+    end
+)
+
+server.register(
+  namespace="clock",
+  description="Dump a description of the current clocks and sources",
+  "dump",
+  fun (_) -> clock.dump()
+)
+
+server.register(
+  namespace="clock",
+  description="Dump the source graph for all active clocks",
+  "dump_all_sources",
+  fun (_) -> clock.dump_all_sources()
+)
+
+on_start(
+  fun () ->
+    begin
+      if
+        settings.request.deprecated_on_air_metadata()
+      then
+        server.register(
+          namespace="request",
+          description="Return all the requests currently on_air (DEPRECATED)!",
+          "on_air",
+          fun (_) ->
+            string.concat(
+              separator=" ",
+              list.map(
+                string,
+                list.sort(
+                  fun (a, b) -> a - b,
+                  list.filter_map(
+                    fun (r) ->
+                      if
+                        list.assoc.mem("on_air", request.metadata(r))
+                      then
+                        request.id(r)
+                      else
+                        null
+                      end,
+                    request.all()
+                  )
+                )
+              )
+            )
+        )
+      end
+    end
+)

--- a/tests/liq/settings.liq
+++ b/tests/liq/settings.liq
@@ -1,0 +1,41 @@
+# Instantiate a new setting.
+# @category Settings
+# @flag hidden
+def settings.make(~comments="", ~(description:string), v) =
+  current_value = ref(v)
+  current_value.{description = description, comments = comments}
+end
+
+# Instantiate a new empty setting.
+# @category Settings
+# @flag hidden
+def settings.make.void(~comments="", (description:string)) =
+  {description = description, comments = comments}
+end
+
+let frame = ()
+
+# Duration of a frame.
+# @category Settings
+def frame.duration =
+  settings.frame.duration
+end
+
+let settings.init.compact_before_start =
+  settings.make(
+    description="Run the OCaml memory compaction algorithm before starting your \
+     script. This is useful when script caching is not possible but initial \
+     memory consumption is a concern. This will result in a large chunk of \
+     memory being freed right before starting the script. This also increases \
+     the script's initial startup time.",
+    true
+  )
+
+# Top-level init module for convenience.
+# @category Settings
+# @flag hidden
+init = settings.init
+
+on_start(
+  {if settings.init.compact_before_start() then runtime.gc.compact() end}
+)

--- a/tests/liq/socket.liq
+++ b/tests/liq/socket.liq
@@ -1,0 +1,33 @@
+# Open a named UNIX socket and connect as a client.
+# @param ~non_blocking Open in non-blocking mode.
+# @category File
+def socket.unix.client(~non_blocking=false, path) =
+  s = socket.unix(domain=socket.domain.unix)
+  s.non_blocking(non_blocking)
+  s.connect(socket.address.unix(path))
+  (s : socket).{read = s.read, write = s.write, type = s.type, close = s.close}
+end
+
+# Open a named socket and wait for a client to connect
+# @param ~non_blocking Open in non-blocking mode.
+# @category File
+def socket.unix.listen(~non_blocking=false, path) =
+  s = socket.unix(domain=socket.domain.unix)
+  s.non_blocking(non_blocking)
+  s.bind(socket.address.unix(path))
+  s.listen(1)
+  let (s', _) = s.accept()
+  close =
+    fun () ->
+      begin
+        s'.close()
+        s.close()
+      end
+
+  (s' : socket).{
+    read = s'.read,
+    write = s'.write,
+    type = s'.type,
+    close = close
+  }
+end

--- a/tests/liq/source.liq
+++ b/tests/liq/source.liq
@@ -1,0 +1,362 @@
+# Create an audio source from the given track, with
+# metadata and track marks from that same track.
+# @category Source / Track processing
+def source.audio(~id=null("source.audio"), audio) =
+  source(
+    id=id,
+    {
+      audio = audio,
+      metadata = track.metadata(audio),
+      track_marks = track.track_marks(audio)
+    }
+  )
+end
+
+# Create a video source from the given track, with
+# metadata and track marks from that same track.
+# @category Source / Track processing
+def source.video(~id=null("source.video"), video) =
+  source(
+    id=id,
+    {
+      video = video,
+      metadata = track.metadata(video),
+      track_marks = track.track_marks(video)
+    }
+  )
+end
+
+# Remove duplicate metadata in a track.
+# @param ~using Labels to use to compare the metadata. Defaults to all of them \
+#               when `null`.
+# @category Metadata
+def track.metadata.deduplicate(
+  ~id=null("track.metadata.deduplicate"),
+  ~using=null,
+  t
+) =
+  last_meta = ref([])
+
+  def f(m) =
+    m =
+      if
+        null.defined(using)
+      then
+        using = null.get(using)
+        list.filter(fun (x) -> list.mem(fst(x), using), m)
+      else
+        m
+      end
+
+    if
+      m == last_meta()
+    then
+      []
+    else
+      last_meta := m
+      m
+    end
+  end
+
+  track.metadata.map(
+    id=id,
+    insert_missing=false,
+    update=false,
+    strip=true,
+    f,
+    t
+  )
+end
+
+# Remove duplicate metadata in a source.
+# @category Metadata
+# @param ~using Labels to use to compare the metadata. Defaults to all of them \
+#               when `null`.
+# @param ~id Source id
+# @param s source
+def metadata.deduplicate(~id=null("metadata.deduplicate"), ~using=null, s) =
+  tracks = source.tracks(s)
+  source(
+    id=id,
+    tracks.{metadata = track.metadata.deduplicate(using=using, tracks.metadata)}
+  )
+end
+
+# Rewrite metadata on the fly using a function.
+# @category Source / Track processing
+# @argsof track.metadata.map
+def metadata.map(
+  ~id=null("metadata.map"),
+  %argsof(track.metadata.map[!id]),
+  f,
+  (s:source)
+) =
+  tracks = source.tracks(s)
+  source(
+    id=id,
+    tracks.{
+      metadata =
+        track.metadata.map(%argsof(track.metadata.map), f, tracks.metadata)
+    }
+  )
+end
+
+# Turn a source into an infaillible source by adding blank when the source is
+# not available.
+# @param s the source to turn infaillible
+# @category Source / Track processing
+def mksafe(~id="mksafe", s) =
+  fallback(
+    id=id,
+    [(s : source).{track_sensitive = false}, blank(id="safe_blank")]
+  )
+end
+
+# Creates a source that plays only one track of the input source.
+# @category Source / Track processing
+# @param s The input source.
+def once(~id=null("once"), s) =
+  sequence(id=id, [(s : source), source.fail()])
+end
+
+# Skip track when detecting a blank.
+# @category Source / Track processing
+# @param ~id Force the value of the source ID.
+# @param ~threshold Power in decibels under which the stream is considered silent.
+# @param ~max_blank Maximum silence length allowed, in seconds.
+# @param ~min_noise Minimum duration of noise required to end silence, in seconds.
+# @param ~track_sensitive Reset blank counter at each track.
+def blank.skip(
+  ~id=null("blank.skip"),
+  ~threshold=-40.,
+  ~max_blank=20.,
+  ~min_noise=0.,
+  ~track_sensitive=true,
+  s
+) =
+  s' =
+    blank.detect(
+      id=id,
+      threshold=threshold,
+      max_blank=max_blank,
+      min_noise=min_noise,
+      track_sensitive=track_sensitive,
+      s
+    )
+  s'.on_blank(synchronous=true, source.methods(s).skip)
+  s'
+end
+
+# Run a function regularly. This is similar to `thread.run` but based on a
+# source internal time instead of the computer's time.
+# @category Source / Track processing
+# @param s Source whose time is taken as reference.
+# @param ~delay Time to wait before the first run (in seconds).
+# @param ~every How often to run the function (in seconds). The function is run once if `null`.
+# @param f Function to run.
+def source.run(s, ~delay=0., ~every=null, f) =
+  next = ref(delay)
+
+  def check() =
+    if
+      source.time(s) >= next()
+    then
+      null.case(
+        every,
+        {next := infinity},
+        fun (every) -> next := next() + every
+      )
+
+      f()
+    end
+  end
+
+  source.methods(s).on_frame(synchronous=true, check)
+  s
+end
+
+# Append an extra track to every track. Set the metadata ‘liq_append’ to
+# `false` to inhibit appending on one track.
+# @category Source / Track processing
+# @param f Given the metadata, build the source producing the track to append. The function can return `null` to prevent appending a new track.
+# @param ~insert_missing Treat track beginnings without metadata as having empty one.
+# @param ~merge Merge the track with its appended track.
+# @flag extra
+def append(~id=null("append"), ~insert_missing=true, ~merge=false, s, f) =
+  last_meta = ref(null)
+  pending = ref(null)
+
+  def next() =
+    p = pending()
+    pending := null
+    last_meta := null
+
+    if null.defined(p) then null.get(p) else (s : source) end
+  end
+
+  d =
+    source.dynamic(
+      track_sensitive=true,
+      merge={merge and null.defined(pending)},
+      next
+    )
+
+  def f(m) =
+    if
+      d.current_source() == (s : source)
+    then
+      if
+        m["liq_append"] == "false"
+      then
+        last_meta := null
+        pending := null
+      elsif
+        last_meta() != m
+      then
+        last_meta := m
+        s = f(m)
+        s = d.prepare(s)
+        pending := s
+      end
+    end
+  end
+
+  if insert_missing then d.on_track(synchronous=true, f) end
+  d.on_metadata(synchronous=true, f)
+
+  s = fallback(id=id, [d, s])
+  s.{
+    pending =
+      # Return the pending source
+      fun () -> pending(),
+    set_pending =
+      # Set the pending source
+      fun (s) -> pending.set(s),
+    cancel_pending =
+      # Cancel any pending appended source.
+      fun () -> pending.set(null),
+    skip =
+      # Skip the current track. Pending appended source are cancelled by default. Pass `cancel_pending=false` to keep it.
+      fun (~cancel_pending=true) ->
+        begin
+          if cancel_pending then pending.set(null) end
+          s.skip()
+        end
+  }
+end
+
+# Prepend an extra track before every track. Set the metadata `liq_prepend` to
+# `false` to inhibit prepending on one track.
+# @category Source / Track processing
+# @param f Given the metadata, build the source producing the track to append. The function can return `null` to prevent any track prepend.
+# @param ~merge Merge the track with its appended track.
+# @flag extra
+def prepend(~id=null("prepend"), ~merge=false, s, f) =
+  last_meta = ref(null)
+
+  def on_meta(m) =
+    if
+      m["liq_prepend"] == "false"
+    then
+      last_meta := null
+    elsif
+      last_meta() != m
+    then
+      last_meta := m
+    end
+  end
+
+  s.on_track(
+    synchronous=true,
+    fun (m) -> m == [] ? last_meta := null : on_meta(m)
+  )
+  s.on_metadata(synchronous=true, on_meta)
+
+  def next() =
+    if
+      null.defined(last_meta)
+    then
+      m = last_meta()
+      last_meta := null
+      if
+        null.defined(m)
+      then
+        m = null.get(m)
+        p = (f(m) : source?)
+        if
+          null.defined(p)
+        then
+          sequence(merge=merge, [null.get(p), s])
+        else
+          s
+        end
+      else
+        s
+      end
+    else
+      s
+    end
+  end
+
+  d = source.dynamic(track_sensitive=true, next)
+  fallback(id=id, [d, s])
+end
+
+# Call a callback on each subtitle in the source.
+# @category Source / Track processing
+# @param f Callback function called on each subtitle.
+# @argsof track.on_subtitle
+def on_subtitle(
+  ~id=null("on_subtitle"),
+  %argsof(track.on_subtitle[!id]),
+  f,
+  s
+) =
+  let {subtitles, ...tracks} = source.tracks(s)
+  source(
+    id=id,
+    tracks.{
+      subtitles =
+        track.on_subtitle(%argsof(track.on_subtitle[!id]), f, subtitles)
+    }
+  )
+end
+
+# Map a function over each subtitle in the source.
+# @category Source / Track processing
+# @param f Callback function called on each subtitle. Returns transformed subtitle or null to filter out.
+# @argsof track.subtitles.map
+def subtitles.map(
+  ~id=null("subtitles.map"),
+  %argsof(track.subtitles.map[!id]),
+  f,
+  s
+) =
+  let {subtitles, ...tracks} = source.tracks(s)
+  source(
+    id=id,
+    tracks.{
+      subtitles =
+        track.subtitles.map(%argsof(track.subtitles.map[!id]), f, subtitles)
+    }
+  )
+end
+
+# Allow inserting subtitles into the source.
+# subtitles track is created is the source does
+# not have one.
+# @category Source / Track processing
+# @argsof track.subtitles.insert
+def subtitles.insert(
+  ~id=null("subtitles.insert"),
+  %argsof(track.subtitles.insert[!id]),
+  s
+) =
+  tracks = source.tracks(s)
+  subtitles = tracks?.subtitles
+  let subtitles =
+    track.subtitles.insert(%argsof(track.subtitles.insert[!id]), subtitles)
+  source(id=id, tracks.{subtitles = subtitles}).{
+    insert_subtitle = subtitles.insert_subtitle
+  }
+end

--- a/tests/liq/sqlite.liq
+++ b/tests/liq/sqlite.liq
@@ -1,0 +1,161 @@
+%ifdef sqlite
+# @docof sqlite
+def replaces sqlite(file) =
+  db = sqlite(file)
+
+  # Insert a list of key / value pairs, where all the values are
+  # strings.
+  def db.insert.list(~table, entries) =
+    let (columns, values) =
+      list.fold(
+        fun (result, entry) ->
+          begin
+            let (columns, values) = result
+            let (column, value) = entry
+            ([...columns, column], [...values, sqlite.escape(value)])
+          end,
+        ([], []),
+        entries
+      )
+
+    columns =
+      string.concat(
+        separator=", ",
+        columns
+      )
+    values =
+      string.concat(
+        separator=", ",
+        values
+      )
+    sql =
+      "INSERT INTO #{sqlite.escape(table)} (#{columns}) VALUES (#{values})"
+
+    db.exec(sql)
+  end
+
+  def db.select(~table, what="*", ~where="", ~limit=null) =
+    where =
+      if
+        where == ""
+      then
+        ""
+      else
+        " WHERE #{where}"
+      end
+    limit =
+      if
+        null.defined(limit)
+      then
+        " LIMIT #{null.get(limit)}"
+      else
+        ""
+      end
+    db.query(
+      "SELECT #{what} FROM #{table}#{where}#{limit}"
+    )
+  end
+
+  def db.select.iter(f, ~table, what="*", ~where="") =
+    where =
+      if
+        where == ""
+      then
+        ""
+      else
+        " WHERE #{where}"
+      end
+    db.iter(
+      f,
+      "SELECT #{what} FROM #{table}#{where}"
+    )
+  end
+
+  def db.delete(~table, ~where="") =
+    where =
+      if
+        where == ""
+      then
+        ""
+      else
+        " WHERE #{where}"
+      end
+    db.exec(
+      "DELETE FROM #{table}#{where}"
+    )
+  end
+
+  # Count the number of items matching a condition.
+  def db.count(~table, ~where="") =
+    where =
+      if
+        where == ""
+      then
+        ""
+      else
+        " WHERE " ^
+          where
+      end
+    let sqlite.query ([{count}] : [{count: int}]) =
+      db.query(
+        "SELECT COUNT(*) AS count FROM #{table}#{where}"
+      )
+    count
+  end
+
+  # Operations on tables.
+  let db.table = ()
+
+  def db.table.drop(table, ~existing=true) =
+    existing =
+      if
+        existing
+      then
+        " IF EXISTS"
+      else
+        ""
+      end
+    db.exec(
+      "DROP TABLE#{existing} #{table}"
+    )
+  end
+
+  # Create a table with given fields.
+  # @param ~preserve Preserve previous table if one already exists under the same name.
+  def db.table.create(table, ~preserve=false, fields) =
+    preserve =
+      if
+        preserve
+      then
+        " IF NOT EXISTS"
+      else
+        ""
+      end
+    fields =
+      string.concat(
+        separator=", ",
+        list.map(
+          fun (lt) ->
+            "#{fst(lt)} #{snd(lt)}",
+          fields
+        )
+      )
+    db.exec(
+      "CREATE TABLE#{preserve} #{table} (#{fields})"
+    )
+  end
+
+  # Check whether a table exists.
+  def db.table.exists(name) =
+    let sqlite.query ([{name}] : [{name: string}]) =
+      db.query(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name=#{
+          sqlite.escape(name)
+        }"
+      )
+    name
+  end
+
+  db
+end
+%endif

--- a/tests/liq/stdlib.liq
+++ b/tests/liq/stdlib.liq
@@ -1,0 +1,172 @@
+%include "error.liq"
+%include "null.liq"
+%include "ref.liq"
+%include "list.liq"
+%include "math.liq"
+%include "getter.liq"
+%include "predicate.liq"
+%include "settings.liq"
+%include "log.liq"
+%include "thread.liq"
+%include "process.liq"
+%include "string.liq"
+%include "socket.liq"
+%include "cron.liq"
+%include "file.liq"
+%include "switches.liq"
+%include "utils.liq"
+%include "clock.liq"
+%include "metadata.liq"
+%include "nfo.liq"
+%include "playlist.liq"
+%include "source.liq"
+%include "tracks.liq"
+%include "request.liq"
+%include "audio.liq"
+%include "fades.liq"
+%include "autocue.liq"
+%include "replaygain.liq"
+%include "lufs.liq"
+%include "http_codes.liq"
+%include "http.liq"
+%include "protocols.liq"
+%include "resolvers.liq"
+%include "icecast.liq"
+%include "hls.liq"
+%include "video.liq"
+%include "ffmpeg.liq"
+%include "profiler.liq"
+%include "io.liq"
+%include "sqlite.liq"
+%include "medialib.liq"
+%include "runtime.liq"
+%include "server.liq"
+%include "sqlite.liq"
+%include "testing.liq"
+%include "liquidsoap.liq"
+
+%include_extra "extra/file.liq"
+%include_extra "extra/native.liq"
+%include_extra "extra/audio.liq"
+%include_extra "extra/source.liq"
+%include_extra "extra/http.liq"
+%include_extra "extra/externals.liq"
+%include_extra "extra/audioscrobbler.liq"
+%include_extra "extra/server.liq"
+%include_extra "extra/telnet.liq"
+%include_extra "extra/interactive.liq"
+%include_extra "extra/visualization.liq"
+%include_extra "extra/openai.liq"
+%include_extra "extra/spinitron.liq"
+%include_extra "extra/metadata.liq"
+%include_extra "extra/fades.liq"
+%include_extra "extra/video.liq"
+
+set_settings_ref(settings)
+
+# Default on_select for both file and live composition profiles. When `ending`
+# is non-null (the ending source was preempted mid-track), fades it out (up to
+# 1s or remaining time). When `replay_metadata` is true, replays the latest
+# metadata on the starting source.
+def source.composition.default_on_select({starting, ending, replay_metadata}) =
+  let {id, insert_metadata, last_metadata} = source.methods(starting)
+
+  # starting can be an active source to insert metadata when the
+  # source is about to be used.
+  def starting() =
+    if
+      replay_metadata
+    then
+      last_metadata = last_metadata()
+      if
+        null.defined(last_metadata)
+      then
+        log.important(
+          label=id(),
+          "Switching to #{id()}: inserting latest metadata"
+        )
+        insert_metadata(null.get(last_metadata))
+      else
+        log.important(
+          label=id(),
+          "Switching to #{id()}: no latest metadata to insert"
+        )
+      end
+    end
+    starting
+  end
+
+  if
+    null.defined(ending)
+  then
+    leaving = null.get(ending)
+
+    let {id} = source.methods(leaving)
+
+    max_fade = 1.
+    rem = source.remaining(leaving)
+    if
+      rem == 0.
+    then
+      starting()
+    else
+      effective_fade = if rem >= 0. then min(rem, max_fade) else max_fade end
+      log.important(
+        label=id(),
+        "Ending #{id()} with a effective_fade #{effective_fade} fade out.."
+      )
+
+      leaving =
+        fade.out(
+          duration=effective_fade,
+          max_duration(effective_fade, sequence([leaving, switch([])]))
+        )
+
+      count = ref(0)
+      def next() =
+        c = count()
+        ref.incr(count)
+        if c == 0 then leaving elsif c == 1 then starting() else null end
+      end
+
+      source.dynamic(track_sensitive=true, next)
+    end
+  else
+    starting()
+  end
+end
+
+source.composition.file(
+  {
+    on_leave =
+      # skip the source when it is preempted mid-track (track_sensitive=false),
+      # so it starts fresh on next selection. When switching at a track
+      # boundary (track_sensitive=true), the source has finished naturally and
+      # no skip is needed.
+
+      fun ({source = s, track_sensitive}) ->
+        if
+          not track_sensitive
+        then
+          log.important(
+            label=source.id(s),
+            "Source left in the middle of a track: skipping current track"
+          )
+          let {skip, clear_last_metadata} = source.methods(s)
+          clear_last_metadata()
+          skip()
+        end,
+    on_select = source.composition.default_on_select,
+    track_sensitive = true,
+    replay_metadata = true
+  }
+)
+
+source.composition.live(
+  {
+    on_leave = fun (_) -> (),
+    on_select = source.composition.default_on_select,
+    track_sensitive = false,
+    replay_metadata = true
+  }
+)

--- a/tests/liq/string.liq
+++ b/tests/liq/string.liq
@@ -1,0 +1,476 @@
+# Match a string with an expression. Perl compatible regular expressions are
+# recognized. Hence, special characters should be escaped. Alternatively, one
+# can use the `r/_/.test(_)` syntax for regular expressions.
+# @category String
+def string.match(~pattern, s) =
+  regexp(pattern).test(s)
+end
+
+# Extract substrings from a string. Perl compatible regular expressions are
+# recognized. Hence, special characters should be escaped. Returns a list of
+# (index,value). If the list does not have a pair associated to some index, it
+# means that the corresponding pattern was not found. Alter natively, one can
+# use the `r/_/.exec(_)` syntax for regular expressions.
+# @category String
+def string.extract(~pattern, s) =
+  regexp(pattern).exec(s)
+end
+
+# Replace all substrings matched by a pattern by another string returned by a
+# function. Alternatively, one can use the `r/_/g.replace(_)` syntax for regular
+# expressions.
+# @category String
+# @param ~pattern Pattern (regular expression) of substrings which should be replaced.
+# @param f Function getting a matched substring an returning the string to replace it with.
+# @param s String whose substrings should be replaced.
+def string.replace(~pattern, f, s) =
+  regexp(flags=["g"], pattern).replace(f, s)
+end
+
+# Split a string at "separator". Perl compatible regular expressions are
+# recognized. Hence, special characters should be escaped. Alternatively, one
+# can use the `r/_/.split(_)` syntax for regular expressions.
+# @category String
+def string.split(~separator, s) =
+  regexp(separator).split(s)
+end
+
+# Return an array of the string's bytes.
+# @category String
+def string.bytes(s) =
+  string.split(separator="", s)
+end
+
+# Return the length of the string in bytes.
+# @category String
+def string.bytes.length(s) =
+  string.length(encoding="ascii", s)
+end
+
+# Split a string in two at first "separator".
+# @category String
+def string.split.first(~encoding=null, ~separator, s) =
+  n = string.length(encoding=encoding, s)
+  l = string.length(encoding=encoding, separator)
+  i = string.index(substring=separator, s)
+  if
+    i < 0
+  then
+    error.raise(
+      error.not_found,
+      "String does not contain the separator."
+    )
+  end
+
+  (
+    string.sub(encoding=encoding, s, start=0, length=i),
+    string.sub(encoding=encoding, s, start=i + l, length=n - (i + l))
+  )
+end
+
+# Test whether a string contains a given prefix, substring or suffix.
+# @category String
+# @param ~encoding Encoding used to split characters. Should be one of: `"utf8"` or `"ascii"`
+# @param ~prefix Prefix to look for.
+# @param ~substring Substring to look for.
+# @param ~suffix Suffix to look for.
+# @param s The string to look into.
+def string.contains(~encoding=null, ~prefix="", ~substring="", ~suffix="", s) =
+  ans = ref(prefix == "" and substring == "" and suffix == "")
+  if
+    prefix != ""
+  then
+    ans :=
+      ans()
+      or string.sub(
+        encoding=encoding,
+        s,
+        start=0,
+        length=string.length(encoding=encoding, prefix)
+      ) ==
+        prefix
+  end
+
+  if
+    suffix != ""
+  then
+    suflen = string.length(encoding=encoding, suffix)
+    ans :=
+      ans()
+      or string.sub(
+        encoding=encoding,
+        s,
+        start=string.length(encoding=encoding, s) - suflen,
+        length=suflen
+      ) ==
+        suffix
+  end
+
+  if
+    substring != ""
+  then
+    sublen = string.length(encoding=encoding, substring)
+    for i = 0 to string.length(encoding=encoding, s) - sublen do
+      ans :=
+        ans()
+        or (
+          string.sub(encoding=encoding, s, start=i, length=sublen) == substring
+        )
+
+    end
+  end
+
+  ans()
+end
+
+# What remains of a string after a given prefix.
+# @category String
+# @param ~encoding Encoding used to split characters. Should be one of: `"utf8"` or `"ascii"`
+# @param ~prefix Requested prefix.
+def string.residual(~encoding=null, ~prefix, s) =
+  n = string.length(encoding=encoding, prefix)
+  if
+    string.contains(encoding=encoding, prefix=prefix, s)
+  then
+    string.sub(
+      encoding=encoding,
+      s,
+      start=n,
+      length=string.length(encoding=encoding, s) - n
+    )
+  else
+    null
+  end
+end
+
+# Test whether a string is a valid integer.
+# @category String
+def string.is_int(s) =
+  try
+    ignore(int_of_string(s))
+    true
+  catch _ do
+    false
+  end
+end
+
+# Convert a string to a int.
+# @category String
+def string.to_int(~default=0, s) =
+  int_of_string(default=default, s)
+end
+
+# Convert an int to string.
+# @category String
+# @param ~digits Minimal number of digits (pad with 0s on the left if necessary).
+def string.of_int(~digits=0, n) =
+  s = string(n)
+  if
+    string.length(s) >= digits
+  then
+    s
+  else
+    string.make(char_code=48, digits - string.bytes.length(s)) ^ s
+  end
+end
+
+# Convert a string to a float.
+# @category String
+def string.to_float(~default=0., s) =
+  float_of_string(default=default, s)
+end
+
+let string.binary = ()
+
+# Value of a positive (unsigned) integer encoded using native memory
+# representation.
+# @category String
+# @param ~little_endian Whether the memory representation is little endian.
+# @param s String containing the binary representation.
+def string.binary.to_int(~little_endian=true, s) =
+  ans = ref(0)
+  n = string.bytes.length(s)
+  for i = 0 to n - 1 do
+    ans :=
+      lsl(ans(), 8) + string.nth(s, if little_endian then n - 1 - i else i end)
+
+  end
+
+  ans()
+end
+
+# Encode a positive (unsigned) integer using native memory representation.
+# @category String
+# @param ~pad Minimum length in digits (pad on the left with zeros in order to reach it)
+# @param ~little_endian Whether the memory representation is little endian.
+# @param s String containing the binary representation.
+def string.binary.of_int(~pad=0, ~little_endian=true, d) =
+  def rec f(d, s) =
+    if
+      d > 0
+    then
+      c = string.hex_of_int(pad=2, (d mod 256))
+      if
+        little_endian
+      then
+        f(lsr(d, 8), "#{s}\\x#{c}")
+      else
+        f(lsr(d, 8), "\\x#{c}#{s}")
+      end
+    else
+      s
+    end
+  end
+
+  ret = d == 0 ? "\\x00" : f(d, "")
+  ret = string.unescape(ret)
+  len = string.bytes.length(ret)
+  if
+    len < pad
+  then
+    ans = string.make(char_code=0, pad - len)
+    if little_endian then "#{ret}#{ans}" else "#{ans}#{ret}" end
+  else
+    ret
+  end
+end
+
+# Add a null character at the end of a string.
+# @category String
+# @param s String.
+def string.null_terminated(s) =
+  s ^ "\000"
+end
+
+# Generate an identifier if no identifier was provided.
+# @category String
+# @param ~default Name from which identifier is generated if not present.
+# @param id Proposed identifier.
+def string.id.default(~default, id) =
+  null.default(id, {string.id(default)})
+end
+
+# Return a quoted copy of the given string.
+# By default, the string is assumed to be `"utf8"` encoded and is escaped
+# following JSON and javascript specification.
+# @category String
+# @param ~encoding One of: `"ascii"` or `"utf8"`. If `null`, `utf8` is tried first and `ascii` is used as a fallback if this fails.
+def string.quote(~encoding=null, s) =
+  def special_char(~encoding, s) =
+    if
+      s == "'"
+    then
+      false
+    else
+      string.escape.special_char(encoding=encoding, s)
+    end
+  end
+
+  s = string.escape(special_char=special_char, encoding=encoding, s)
+  "\"#{s}\""
+end
+
+# Return an unquoted copy of the given string.
+# Quotes are removed by trying to parse the string
+# following the JSON string escaping convention.
+# @category String
+def string.unquote(s) =
+  try
+    let json.parse (s : string) = s
+    s
+  catch _ do
+    s
+  end
+end
+
+let string.data_uri = ()
+
+# Encode a string using the data uri format,
+# i.e. `"data:<mime>[;base64],<data>"`.
+# @category String
+# @param ~base64 Encode data using the base64 format
+# @param ~mime Data mime type
+def string.data_uri.encode(~base64=true, ~(mime:string), s) =
+  s = base64 ? ";base64,#{string.base64.encode(s)}" : ",#{s}"
+  "data:#{mime}#{s}"
+end
+
+# Decode a string using the data uri format,
+# i.e. `"data:<mime>[;base64],<data>"`.
+# @category String
+def string.data_uri.decode(s) =
+  captured =
+    r/^data:(?<mime>[\/\w]+)(?<base64>;base64)?,(?<data>.+)$/.exec(s).groups
+
+  if
+    list.assoc.mem("mime", captured) and list.assoc.mem("data", captured)
+  then
+    mime = list.assoc("mime", captured)
+    data = list.assoc("data", captured)
+    data =
+      if
+        list.assoc.mem("base64", captured)
+      then
+        string.base64.decode(data)
+      else
+        data
+      end
+
+    data.{mime = mime}
+  else
+    null
+  end
+end
+
+let string.getter = ()
+
+# Create a string getter which will return once the given string and then the
+# empty string.
+# @category String
+def string.getter.single(s) =
+  first = ref(true)
+  fun () ->
+    begin
+      if
+        first()
+      then
+        first := false
+        s
+      else
+        ""
+      end
+    end
+end
+
+# Flush all values from a string getter and return
+# the concatenated result. If the getter is constant,
+# return the constant string. Otherwise, call the getter
+# repeatedly until it returns an empty string and return
+# the concatenated result
+# @category String
+def string.getter.flush(~separator="", gen) =
+  if
+    getter.is_constant(gen)
+  then
+    getter.get(gen)
+  else
+    def rec f(data) =
+      chunk = getter.get(gen)
+      if
+        chunk == ""
+      then
+        string.concat(separator=separator, data)
+      else
+        f([...data, chunk])
+      end
+    end
+
+    f([])
+  end
+end
+
+# Combine a list of string getters `[g1, ...]`
+# and return a single getter `g` such that:
+# `string.getter.flush(separator=s, g) = string.concat(separator=s, list.filter(fun (s) -> s != "", [string.getter.flush(g1), ...]))`
+# @category String
+def string.getter.concat(l) =
+  len = list.length(l)
+  pos = ref(0)
+
+  def rec f() =
+    if
+      pos() == len
+    then
+      ""
+    else
+      gen = list.nth(l, pos())
+      ret = getter.get(gen)
+      if ret == "" or getter.is_constant(gen) then ref.incr(pos) end
+      ret == "" ? f() : ret
+    end
+  end
+
+  getter(f)
+end
+
+let string.char.ascii = ()
+
+# All ASCII characters code
+# @category String
+let string.char.ascii = list.init(128, fun (c) -> c)
+
+# All ASCII control character codes
+# @category String
+let string.char.ascii.control = list.init(32, fun (c) -> c)
+
+# All ASCII printable character codes
+# @category String
+let string.char.ascii.printable = list.init(96, fun (c) -> c + 32)
+
+# All ASCII alphabet character codes
+# @category String
+let string.char.ascii.alphabet =
+  [
+    # A-Z
+    ...list.init(24, fun (c) -> c + 65),
+    # a-z
+    ...list.init(24, fun (c) -> c + 97)
+  ]
+
+# All ASCII number character codes
+# @category String
+let string.char.ascii.number = list.init(10, fun (c) -> c + 48)
+
+# Return a random ASCII character
+# @category String
+def string.char.ascii.random(range=[...string.char.ascii]) =
+  string.char(list.nth(range, random.int(min=0, max=list.length(range) - 1)))
+end
+
+# Escape HTML entities.
+# @category String
+# @argsof string.escape[encoding]
+def string.escape.html(%argsof(string.escape[encoding]), s) =
+  escaped =
+    [
+      ("&", "&amp;"),
+      ("<", "&lt;"),
+      (">", "&gt;"),
+      ('"', "&quot;"),
+      ("'", "&#39;")
+    ]
+
+  def special_char(~encoding:_, c) =
+    list.assoc.mem(c, escaped)
+  end
+
+  def escape_char(~encoding:_, c) =
+    escaped[c]
+  end
+
+  string.escape(
+    %argsof(string.escape[encoding]),
+    special_char=special_char,
+    escape_char=escape_char,
+    s
+  )
+end
+
+# Generate a given number of spaces (this can be useful for indenting).
+# @category String
+# @param n Number of spaces.
+def string.spaces(n) =
+  string.make(char_code=32, n)
+end
+
+# Convert a string to uppercase.
+# @category String
+def string.uppercase(s) =
+  string.case(lower=false, s)
+end
+
+# Convert a string to lowercase.
+# @category String
+def string.lowercase(s) =
+  string.case(lower=true, s)
+end

--- a/tests/liq/switches.liq
+++ b/tests/liq/switches.liq
@@ -1,0 +1,197 @@
+# At the beginning of each track, select the first ready child.
+# @category Source / Track processing
+# @param ~id Force the value of the source ID.
+def fallback(~id=null, sources) =
+  switch(id=id, list.map(fun (s) -> ({true}, s), sources))
+end
+
+# Rotate between sources.
+# @category Source / Track processing
+# @param ~id Force the value of the source ID.
+def rotate(~id=null, sources) =
+  sources =
+    (sources :
+      [
+        source.{
+          on_select?: (
+            {ending: source?, replay_metadata: bool, starting: source}
+          )->source,
+          on_leave?: ({source: source, track_sensitive: bool})->unit,
+          single?: bool,
+          track_sensitive?: getter(bool),
+          weight?: getter(int)
+        }
+      ]
+    )
+
+  sources = list.map(fun (s) -> s.{weight = s?.weight ?? getter(1)}, sources)
+  failed = (source.fail() : source)
+
+  # Currently selected index
+  picked_index = ref(-1)
+
+  # Number of tracks played per selected source
+  # source IDs can change between calls..
+  tracks_played =
+    list.map(fun (s) -> ((fun () -> source.id(s)), ref(0)), sources)
+
+  tracks_played =
+    fun () ->
+      list.map(
+        fun (x) ->
+          begin
+            label_fn = fst(x)
+            (label_fn(), snd(x))
+          end,
+        tracks_played
+      )
+
+  # Find index of next source to play, i.e. first ready source after currently
+  # selected one.
+  def pick() =
+    list.iter((fun (el) -> snd(el) := 0), tracks_played())
+    if
+      list.exists(source.is_ready, sources)
+    then
+      def rec f(index) =
+        s = list.nth(default=failed, sources, index)
+        if
+          source.is_ready(s)
+        then
+          picked_index := index
+        else
+          f((index + 1) mod list.length(sources))
+        end
+      end
+
+      f((picked_index() + 1) mod list.length(sources))
+    else
+      picked_index := -1
+    end
+  end
+
+  # Add condition to i-th source.
+  def add_condition(index, s) =
+    def cond() =
+      if picked_index() == -1 then pick() end
+      if
+        picked_index() != -1
+      then
+        picked_source = list.nth(sources, picked_index())
+        fn = list.assoc(source.id(picked_source), tracks_played())
+        if getter.get(picked_source.weight) <= fn() then pick() end
+      end
+
+      picked_index() == index
+    end
+
+    (cond, s)
+  end
+
+  s = switch(list.mapi(add_condition, sources))
+
+  def f(_) =
+    if
+      null.defined(s.selected())
+    then
+      selected_id = source.id(null.get(s.selected()))
+      if
+        list.assoc.mem(selected_id, tracks_played())
+      then
+        played = list.assoc(selected_id, tracks_played())
+        ref.incr(played)
+      end
+    end
+  end
+
+  s.on_track(synchronous=true, f)
+
+  def replaces s =
+    fallback(id=id, s::sources)
+  end
+
+  s
+end
+
+# At the beginning of every track, select a random ready child.
+# @category Source / Track processing
+# @param ~id Force the value of the source ID.
+def replaces random(~id=null, sources) =
+  sources =
+    (sources :
+      [
+        source.{
+          on_select?: (
+            {ending: source?, replay_metadata: bool, starting: source}
+          )->source,
+          on_leave?: ({source: source, track_sensitive: bool})->unit,
+          single?: bool,
+          track_sensitive?: getter(bool),
+          weight?: getter(int)
+        }
+      ]
+    )
+
+  sources = list.map(fun (s) -> s.{weight = s?.weight ?? getter(1)}, sources)
+  next_index = ref(-1)
+
+  def pick() =
+    def available_weighted_sources(cur, s) =
+      let (index, current_weight, indexes) = cur
+      let (current_weight, indexes) =
+        if
+          source.is_ready((s : source.{ weight: getter(int) }))
+        then
+          weight = getter.get(s.weight)
+          indexes = (current_weight, current_weight + weight, index)::indexes
+          (current_weight + weight, indexes)
+        else
+          (current_weight, indexes)
+        end
+
+      (index + 1, current_weight, indexes)
+    end
+
+    let (_, total_weight, weighted_indexes) =
+      list.fold(available_weighted_sources, (0, 0, []), sources)
+
+    picked_weight =
+      if total_weight > 0 then random.int(min=0, max=total_weight) else 0 end
+
+    def pick_source(picked_index, el) =
+      let (lower_bound, upper_bound, index) = el
+      if
+        lower_bound <= picked_weight and picked_weight < upper_bound
+      then
+        index
+      else
+        picked_index
+      end
+    end
+
+    next_index := list.fold(pick_source, -1, weighted_indexes)
+  end
+
+  def add_condition(index, s) =
+    def cond() =
+      if next_index() == -1 then pick() end
+      next_index() == index
+    end
+
+    (cond, s)
+  end
+
+  s = switch(list.mapi(add_condition, sources))
+
+  def f(_) =
+    next_index := -1
+  end
+
+  s.on_track(synchronous=true, f)
+
+  def replaces s =
+    fallback(id=id, s::sources)
+  end
+
+  s
+end

--- a/tests/liq/testing.liq
+++ b/tests/liq/testing.liq
@@ -1,0 +1,37 @@
+# Sleep regularly, thus inducing delays in the sound production. This is mainly
+# useful for emulating network delays or sources which are slow to produce data,
+# and thus test bufferization and robustness of scripts.
+# @category Source / Testing
+# @flag experimental
+# @param ~every How often we should sleep (in seconds, 0 means every frame).
+# @param ~delay Delay introduced (in seconds).
+# @param ~delay_random Maximum amount of time randomly added to the delay (in seconds).
+# @param ~on_delay Function called when a delay is introduced, with the delay as argument.
+# @param s Source in which the delays should be introduced.
+# @method frozen The stream production is frozen while set to `true`.
+def sleeper(
+  ~every=1.,
+  ~delay=1.1,
+  ~delay_random=0.,
+  ~on_delay=fun (_) -> (),
+  s
+) =
+  last = ref(0.)
+  frozen = ref(false)
+
+  def f() =
+    while frozen() do thread.pause(0.1)  end
+    now = source.time(s)
+    if
+      now >= last() + every
+    then
+      last := now
+      delay = delay + random.float(max=delay_random)
+      on_delay(delay)
+      thread.pause(delay)
+    end
+  end
+
+  source.methods(s).on_frame(synchronous=true, f)
+  s.{frozen = frozen}
+end

--- a/tests/liq/thread.liq
+++ b/tests/liq/thread.liq
@@ -1,0 +1,161 @@
+# Run a function in a separate thread.
+# @category Programming
+# @param ~fast Whether the thread is supposed to return quickly or not. Typically, blocking tasks (e.g. fetching data over the internet) should not be considered to be fast. When set to `false` its priority will be lowered below that of request resolutions and fast timeouts. This is only effective if you set a dedicated queue for fast tasks, see the "scheduler" settings for more details.
+# @param ~delay Delay (in seconds) after which the thread should be launched.
+# @param ~every How often (in seconds) the thread should be run. If negative or `null`, run once.
+# @param ~on_error Error callback executed when an error occurred while running the given function. When passed, \
+#                  all raised errors are silenced unless re-raised by the callback.
+# @param f Function to execute.
+def replaces thread.run(~fast=true, ~delay=0., ~on_error=null, ~every=null, f) =
+  every = every ?? getter(-1.)
+
+  def f() =
+    ignore(f() == ())
+    getter.get(every)
+  end
+
+  on_error =
+    null.map(
+      fun (fn) ->
+        fun (err) ->
+          begin
+            (fn(err) : unit)
+            (-1.)
+          end,
+      on_error
+    )
+
+  thread.run.recurrent(fast=fast, delay=delay, on_error=on_error, f)
+end
+
+# Unless told not to, we want to batch thread.when calls when the getter is a fixed
+# value. We batch them by getter value. All callbacks are expected to be fast so we
+# do a single global callback for all batched calls. After tasks_count_warning is
+# reached that they might need to refactor their code.
+let thread.when =
+  {tasks_count = ref(0), tasks_count_warning = 70, batches = ref([])}
+
+# @flag hidden
+def thread.when.add_to_batch(~every, check) =
+  current_batches = thread.when.batches()
+
+  if
+    list.assoc.mem(every, current_batches)
+  then
+    tasks = list.assoc(every, current_batches)
+    tasks := [check, ...tasks()]
+  else
+    tasks = ref([check])
+    errors = ref([])
+    def exec_task(fn) =
+      try
+        fn()
+      catch err do
+        errors := [err, ...errors()]
+      end
+    end
+    def check_tasks() =
+      current_tasks = tasks()
+      list.iter(exec_task, current_tasks)
+      current_errors = errors()
+
+      errors := []
+
+      if
+        current_errors != []
+      then
+        errors_list =
+          string.concat(
+            separator=", ",
+            list.map(string, current_errors)
+          )
+        log.critical(
+          label="thread.when",
+          "Error(s) while executing batched `thread.when`: #{errors_list}"
+        )
+      end
+
+      every
+    end
+    thread.run.recurrent(fast=true, delay=0., on_error=null, check_tasks)
+    thread.when.batches := [(every, tasks), ...current_batches]
+  end
+end
+
+# Execute a callback when a predicate is `true`. The predicate
+# is checked `every` seconds and the callback is
+# called when the predicate returns `true` after having been
+# `false`, following the same semantics as `predicate.activates`.
+# @category Programming
+# @param ~fast Whether the callback is supposed to return quickly or not.
+# @param ~init Detect at beginning.
+# @param ~every How often (in sec.) to check for the predicate.
+# @param ~once Execute the function only once.
+# @param ~changed Execute the function only if the predicate was false when last checked.
+# @param ~batched When `fast` is `true`, `every` is a fixed value, `on_error` is `null` and `once` is `false`, \
+#                 we batch callbacks to make it more efficient. Set this argument to `false` to disable that.
+# @param ~on_error Error callback executed when an error occurred while running the given function. When passed, \
+#                  all raised errors are silenced unless re-raised by the callback.
+# @param p Predicate indicating when to execute the function, typically a time interval such as `{10h-10h30}`.
+# @param f Function to execute when the predicate is true.
+def thread.when(
+  ~fast=true,
+  ~init=true,
+  ~every=getter(0.5),
+  ~once=false,
+  ~changed=true,
+  ~on_error=null,
+  ~batched=true,
+  p,
+  f
+) =
+  ref.incr(thread.when.tasks_count)
+  if
+    thread.when.tasks_count() == thread.when.tasks_count_warning + 1
+  then
+    log.critical(
+      label="thread.when",
+      "There are over #{thread.when.tasks_count_warning} `thread.when` tasks \
+       running! You might want to consider refactoring your script to use a \
+       single callback!"
+    )
+  end
+
+  p = once or not changed ? p : (predicate.activates(init=init, p))
+
+  def check() =
+    if
+      p()
+    then
+      f()
+      once ? (-1.) : (getter.get(every))
+    else
+      getter.get(every)
+    end
+  end
+
+  if
+    (
+      batched
+      and getter.is_constant(every)
+      and not null.defined(on_error)
+      and fast
+      and not once
+    )
+  then
+    thread.when.add_to_batch(every=getter.get(every), fun () -> ignore(check()))
+  else
+    thread.run.recurrent(fast=fast, delay=0., on_error=on_error, check)
+  end
+end
+
+# @flag hidden
+def default_error_handler(~backtrace, err) =
+  log(
+    label="runtime",
+    level=1,
+    "Uncaught error #{err}!\n#{backtrace}"
+  )
+end
+
+thread.on_error(null, default_error_handler)

--- a/tests/liq/tracks.liq
+++ b/tests/liq/tracks.liq
@@ -1,0 +1,100 @@
+let source.mux = ()
+let source.mux.track = ()
+
+# Replace the audio track of a source.
+# @category Source / Track processing
+def source.mux.track.audio(~id=null, ~audio, s) =
+  source(id=id, source.tracks(s).{audio = audio})
+end
+
+# Replace the video track of a source.
+# @category Source / Track processing
+def source.mux.track.video(~id=null, ~video, s) =
+  source(id=id, source.tracks(s).{video = video})
+end
+
+# Replace the audio track of a source by the one of another source.
+# @category Source / Track processing
+# @param ~audio Source whose audio track is to be taken.
+def source.mux.audio(~id=null, ~(audio:source), s) =
+  source.mux.track.audio(id=id, audio=source.tracks(audio).audio, s)
+end
+
+# Replace the video track of a source by the one of another source.
+# @category Source / Track processing
+# @param ~audio Source whose video track is to be taken.
+def source.mux.video(~id=null, ~(video:source), s) =
+  source.mux.track.video(id=id, video=source.tracks(video).video, s)
+end
+
+# Replace the midi track of a source by the one of another source.
+# @category Source / Track processing
+# @param ~midi Source whose midi track is to be taken.
+def source.mux.midi(~id=null, ~(midi:source), s) =
+  source(id=id, source.tracks(s).{midi = source.tracks(midi).midi})
+end
+
+let source.drop = ()
+
+# Remove the audio track of a source.
+# @category Source / Track processing
+def source.drop.audio(~id=null, s) =
+  let {audio = _, ...tracks} = source.tracks(s)
+  source(id=id, tracks)
+end
+
+# Remove the video track of a source.
+# @category Source / Track processing
+def source.drop.video(~id=null, s) =
+  let {video = _, ...tracks} = source.tracks(s)
+  source(id=id, tracks)
+end
+
+# Remove the midi track of a source.
+# @category Source / Track processing
+def source.drop.midi(~id=null, s) =
+  let {midi = _, ...tracks} = source.tracks(s)
+  source(id=id, tracks)
+end
+
+# Remove the metadata track of a source.
+# @category Source / Track processing
+def source.drop.metadata(~id=null, s) =
+  let {metadata = _, ...tracks} = source.tracks(s)
+  source(id=id, tracks)
+end
+
+# Remove the track marks of a source.
+# @category Source / Track processing
+def source.drop.track_marks(~id=null, s) =
+  let {track_marks = _, ...tracks} = source.tracks(s)
+  source(id=id, tracks)
+end
+
+# Remove the metadata and track marks of a source.
+# @category Source / Track processing
+def source.drop.metadata_track_marks(~id=null, s) =
+  let {metadata = _, track_marks = _, ...tracks} = source.tracks(s)
+  source(id=id, tracks)
+end
+
+let settings.amplify =
+  settings.make.void(
+    "Settings for the amplify operator"
+  )
+
+let settings.amplify.override =
+  settings.make(
+    description="Default metadata used to override amplification.",
+    "liq_amplify"
+  )
+
+# @docof track.audio.amplify
+def track.audio.amplify(
+  %argsof(track.audio.amplify[!override]),
+  ~override=getter({(settings.amplify.override() : string?)}),
+  v,
+  t
+) =
+  track.audio.amplify(%argsof(track.audio.amplify), v, t)
+end

--- a/tests/liq/utils.liq
+++ b/tests/liq/utils.liq
@@ -1,0 +1,81 @@
+%ifdef environment
+# Get the value of an environment variable.
+# Returns `default` if the variable is not set.
+# @category System
+def environment.get(~default="", s) =
+  env = environment()
+  if
+    not list.assoc.mem(s, env)
+  then
+    default
+  else
+    list.assoc(default=default, s, env)
+  end
+end
+%endif
+
+# Split the arguments of an url of the form `arg=bar&arg2=bar2` into
+# `[("arg","bar"),("arg2","bar2")]`. The returned strings are decoded (see
+# `url.decode`).
+# @category String
+# @param args Argument string to split.
+def url.split_args(args) =
+  def f(args, x) =
+    if
+      x == ""
+    then
+      args
+    else
+      ret = r/=/.split(x)
+      arg = url.decode(list.nth(default="", ret, 0))
+      val = url.decode(list.nth(default="", ret, 1))
+      [...args, (arg, val)]
+    end
+  end
+
+  l = r/&/.split(args)
+  list.fold(f, [], l)
+end
+
+# Split an url of the form `foo?arg=bar&arg2=bar2` into
+# `("foo",[("arg","bar"),("arg2","bar2")])`. The returned strings are decoded
+# (see `url.decode`).
+# @category String
+# @param uri Url to split.
+def url.split(uri) =
+  ret = r/(?<uri>[^\?]*)\?(?<args>.*)/.exec(uri).groups
+  args = ret["args"]
+  if
+    args != ""
+  then
+    (url.decode(ret["uri"]), url.split_args(args))
+  else
+    (url.decode(uri), [])
+  end
+end
+
+# Memoize the result of a function, making sure it is only executed once.
+# @category Programming
+def memoize(fn) =
+  cached_result = ref([])
+  fun () ->
+    begin
+      if
+        cached_result() != []
+      then
+        list.hd(cached_result())
+      else
+        result = fn()
+        cached_result := [result]
+        result
+      end
+    end
+end
+
+let duration = ()
+
+# Convert a duration in seconds to hour/minutes/seconds
+# @category Time
+def duration.split(d) =
+  {hours = d / 3600, minutes = (d / 60) mod 60, seconds = (d mod 60)}
+end

--- a/tests/liq/video.liq
+++ b/tests/liq/video.liq
@@ -1,0 +1,918 @@
+# Width for all video frames.
+# @category Source / Video processing
+def video.frame.width =
+  settings.frame.video.width
+end
+
+# Height for all video frames.
+# @category Source / Video processing
+def video.frame.height =
+  settings.frame.video.height
+end
+
+# Framerate for all video frames.
+# @category Source / Video processing
+def video.frame.rate =
+  settings.frame.video.framerate
+end
+
+# Generate a source from an image request.
+# @category Source / Video processing
+# @param ~id Force the value of the source ID.
+# @param ~fallible Whether we are allowed to fail (in case the file is non-existent or invalid).
+# @param ~width Scale to width
+# @param ~height Scale to height
+# @param ~x x position.
+# @param ~y y position.
+# @param req Image request
+def request.image(
+  ~id=null,
+  ~fallible=false,
+  ~width=null,
+  ~height=null,
+  ~x=getter(0),
+  ~y=getter(0),
+  req
+) =
+  last_req = ref(null)
+
+  def next() =
+    req = (getter.get(req) : request)
+
+    if
+      req != last_req()
+    then
+      last_req := req
+      image = request.single(id=id, fallible=fallible, req)
+      image = video.crop(image)
+      video.resize(id=id, x=x, y=y, width=width, height=height, image)
+    else
+      null
+    end
+  end
+
+  source.dynamic(id=id, track_sensitive=false, next)
+end
+
+# Generate a source from an image file.
+# @category Source / Video processing
+# @param ~id Force the value of the source ID.
+# @param ~fallible Whether we are allowed to fail (in case the file is non-existent or invalid).
+# @param ~width Scale to width
+# @param ~height Scale to height
+# @param ~x x position.
+# @param ~y y position.
+# @param file Path to the image.
+# @method set Change the request.
+def image(%argsof(request.image), file) =
+  r = getter.map.memoize(fun (file) -> request.create(file), file)
+
+  request.image(%argsof(request.image), r)
+end
+
+# @flag hidden
+let orig_request = request
+
+# Add a static request on the given video track.
+# @category Track / Video processing
+# @param ~id Force the value of the source ID.
+# @param ~fallible Whether we are allowed to fail (in case the file is non-existent or invalid).
+# @param ~width Scale to width
+# @param ~height Scale to height
+# @param ~x x position.
+# @param ~y y position.
+# @param ~request Request to add to the video track
+def track.video.add_request(
+  ~id=null("track.video.add_request"),
+  ~fallible=false,
+  ~width=null,
+  ~height=null,
+  ~x=getter(0),
+  ~y=getter(0),
+  ~request,
+  v
+) =
+  image =
+    orig_request.image(
+      id=id,
+      fallible=fallible,
+      x=x,
+      y=y,
+      width=width,
+      height=height,
+      request
+    )
+
+  let {video = image} = source.tracks(image)
+  track.video.add([v, image])
+end
+
+# Add a static image on the given video track.
+# @category Track / Video processing
+# @param ~id Force the value of the source ID.
+# @param ~fallible Whether we are allowed to fail (in case the file is non-existent or invalid).
+# @param ~width Scale to width
+# @param ~height Scale to height
+# @param ~x x position.
+# @param ~y y position.
+# @param ~file Path to the image file.
+def track.video.add_image(
+  ~id=null("track.video.add_image"),
+  ~fallible=false,
+  ~width=null,
+  ~height=null,
+  ~x=getter(0),
+  ~y=getter(0),
+  ~file,
+  v
+) =
+  image =
+    image(id=id, fallible=fallible, x=x, y=y, width=width, height=height, file)
+
+  let {video = image} = source.tracks(image)
+  track.video.add([v, image])
+end
+
+# Add a static request on the source video channel.
+# @category Source / Video processing
+# @param ~id Force the value of the source ID.
+# @param ~fallible Whether we are allowed to fail (in case the file is non-existent or invalid).
+# @param ~width Scale to width
+# @param ~height Scale to height
+# @param ~x x position.
+# @param ~y y position.
+# @param ~request Request to add to the video channel
+def video.add_request(
+  ~id=null("video.add_request"),
+  ~fallible=false,
+  ~width=null,
+  ~height=null,
+  ~x=getter(0),
+  ~y=getter(0),
+  ~request,
+  (s:source)
+) =
+  let {video, ...tracks} = source.tracks(s)
+  video =
+    track.video.add_request(
+      fallible=fallible,
+      width=width,
+      height=height,
+      x=x,
+      y=y,
+      request=request,
+      video
+    )
+
+  source(id=id, tracks.{video = video})
+end
+
+# Add a static image on the source video channel.
+# @category Source / Video processing
+# @param ~id Force the value of the source ID.
+# @param ~fallible Whether we are allowed to fail (in case the file is non-existent or invalid).
+# @param ~width Scale to width
+# @param ~height Scale to height
+# @param ~x x position.
+# @param ~y y position.
+# @param ~file Path to the image file.
+def video.add_image(
+  ~id=null("video.add_image"),
+  ~fallible=false,
+  ~width=null,
+  ~height=null,
+  ~x=getter(0),
+  ~y=getter(0),
+  ~file,
+  (s:source)
+) =
+  let {video, ...tracks} = source.tracks(s)
+  video =
+    track.video.add_image(
+      fallible=fallible,
+      width=width,
+      height=height,
+      x=x,
+      y=y,
+      file=file,
+      video
+    )
+
+  source(id=id, tracks.{video = video})
+end
+
+# Generate a video source containing cover-art for current track of input audio
+# source.
+# @category Source / Video processing
+# @param s Audio source whose metadata contain cover-art.
+def video.cover(s) =
+  last_filename = ref(null)
+  last_metadata = source.methods(s).last_metadata
+  b = (blank() : source)
+
+  def next() =
+    m = last_metadata() ?? []
+
+    filename = m["filename"]
+
+    if
+      filename != last_filename()
+    then
+      last_filename := filename
+
+      cover =
+        if
+          file.exists(filename)
+        then
+          file.cover(filename)
+        else
+          "".{mime = ""}
+        end
+
+      if
+        null.defined(cover) and null.get(cover) != ""
+      then
+        cover = null.get(cover)
+        extname =
+          (
+            null.defined(cover.mime)
+              ? file.mime.extension(null.get(cover.mime))
+              : null
+          )
+            ?? ".osb"
+        f = file.temp("cover", extname)
+        log.debug(
+          "Found cover for #{filename}."
+        )
+        file.write(data=cover, f)
+        request.once(request.create(temporary=false, f))
+      else
+        log.debug(
+          "No cover for #{filename}."
+        )
+        b
+      end
+    else
+      null
+    end
+  end
+
+  source.dynamic(track_sensitive=false, next)
+end
+
+let output.youtube = ()
+let output.youtube.live = ()
+
+# Stream to youtube using RTMP.
+# @category Source / Output
+# @param ~id Force the value of the source ID.
+# @param ~fallible Allow the child source to fail, in which case the output will be (temporarily) stopped.
+# @param ~start Automatically start outputting whenever possible. If true, an infallible (normal) output will start outputting as soon as it is created, and a fallible output will (re)start as soon as its source becomes available for streaming.
+# @param ~url RTMP URL to stream to
+# @param ~encoder Encoder to use (most likely a `%ffmpeg` encoder)
+# @param ~key Your secret youtube key
+def output.youtube.live.rtmp(
+  ~id=null,
+  ~fallible=false,
+  ~start=true,
+  ~url="rtmp://a.rtmp.youtube.com/live2",
+  ~(key:string),
+  ~encoder,
+  s
+) =
+  output.url(
+    id=id,
+    fallible=fallible,
+    start=start,
+    url="#{url}/#{key}",
+    encoder,
+    s
+  )
+end
+
+# Stream to youtube using HLS.
+# @category Source / Output
+# @param ~id Force the value of the source ID.
+# @param ~fallible Allow the child source to fail, in which case the output will be (temporarily) stopped.
+# @param ~start Automatically start outputting whenever possible. If true, an infallible (normal) output will start outputting as soon as it is created, and a fallible output will (re)start as soon as its source becomes available for streaming.
+# @param ~segment_duration Segment duration (in seconds).
+# @param ~segments Number of segments per playlist.
+# @param ~segments_overhead Number of segments to keep after they have been featured in the live playlist.
+# @param ~url HLS URL to stream to
+# @param ~encoder Encoder to use (most likely a `%ffmpeg` encoder)
+# @param ~key Your secret youtube key
+def output.youtube.live.hls(
+  ~id=null,
+  ~fallible=false,
+  ~segment_duration=2.0,
+  ~segments=4,
+  ~segments_overhead=4,
+  ~start=true,
+  ~url="https://a.upload.youtube.com/http_upload_hls",
+  ~(key:string),
+  ~encoder,
+  s
+) =
+  id = string.id.default(default="output.youtube.live.hls", id)
+
+  def file_url(fname) =
+    "#{url}?cid=#{key}&copy=0&file=#{fname}"
+  end
+
+  def on_file_change({state, path = fname}) =
+    if
+      (state == "created" or state == "updated")
+      and path.basename(fname) != "main.m3u8"
+    then
+      try
+        ignore(http.post(data=file.read(fname), file_url(path.basename(fname))))
+      catch err do
+        log(
+          label=id,
+          level=3,
+          "Error while uploading: #{err}"
+        )
+      end
+    end
+  end
+
+  tmpdir = file.temp_dir("hls", "")
+  on_shutdown({file.rmdir(tmpdir)})
+  o =
+    output.file.hls(
+      id=id,
+      start=start,
+      fallible=fallible,
+      playlist="main.m3u8",
+      segment_duration=segment_duration,
+      segments=segments,
+      segments_overhead=segments_overhead,
+      tmpdir,
+      [("live", encoder)],
+      s
+    )
+  o.on_file_change(synchronous=false, on_file_change)
+  o
+end
+
+# @flag hidden
+def add_text_builder(f) =
+  def at(
+    ~id=null,
+    ~duration=null,
+    ~color=getter(0xffffff),
+    ~cycle=true,
+    ~font=null,
+    ~metadata=null,
+    ~size=getter(18),
+    ~speed=0,
+    ~x=getter(10),
+    ~y=getter(10),
+    ~on_cycle={()},
+    text,
+    s
+  ) =
+    available = s.is_ready
+
+    # Handle modifying the text with metadata.
+    tref = ref(getter.get(text))
+    text = null.defined(metadata) ? tref : text
+
+    def on_metadata(m) =
+      if
+        null.defined(metadata)
+      then
+        m = m[null.get(metadata)]
+        if m != "" then tref := m end
+      end
+    end
+
+    if
+      null.defined(metadata)
+    then
+      s.on_metadata(synchronous=true, on_metadata)
+    end
+
+    # Our text source.
+    t = f(id=id, duration=duration, color=color, font=font, size=size, text)
+    t = video.info(video.crop(t))
+
+    # Handle scrolling if necessary.
+    x =
+      if
+        speed == 0
+      then
+        x
+      else
+        fps = video.frame.rate()
+        x = ref(getter.get(x))
+
+        def x() =
+          if
+            cycle and x() < 0 - t.width()
+          then
+            on_cycle()
+            x := video.frame.width()
+          end
+
+          x := x() - getter.get(speed) / fps
+          x()
+        end
+
+        x
+      end
+
+    t = video.translate(x=x, y=y, t)
+
+    # Ensure that we fail when s fails.
+    t = source.available(t, available)
+
+    # Add the text to the original source.
+    let {video = v, ...tracks} = source.tracks(s)
+    let {video = t} = source.tracks(t)
+    let v = track.video.add([v, t])
+    source(tracks.{video = v})
+  end
+
+  at
+end
+
+let video.add_text = ()
+let video.text.available = ref([])
+
+# Add a text to a stream (native implementation).
+# @category Source / Video processing
+# @param ~id Force the value of the source ID.
+# @param ~color Text color (in 0xRRGGBB format).
+# @param ~cycle Cycle text when it reaches left boundary.
+# @param ~font Path to ttf font file.
+# @param ~metadata Change text on a particular metadata (empty string means disabled).
+# @param ~size Font size.
+# @param ~speed Horizontal speed in pixels per second (`0` means no scrolling and update according to `x` and `y` in case they are variable).
+# @param ~x x offset.
+# @param ~y y offset.
+# @params d Text to display.
+def video.add_text.native =
+  add_text_builder(video.text.native)
+end
+
+video.text.available :=
+  [("native", video.text.native), ...video.text.available()]
+
+%ifdef video.text.gd
+video.text.available := [("gd", video.text.gd), ...video.text.available()]
+
+# Add a text to a stream (GD implementation).
+# @category Source / Video processing
+# @param ~id Force the value of the source ID.
+# @param ~color Text color (in 0xRRGGBB format).
+# @param ~cycle Cycle text when it reaches left boundary.
+# @param ~font Path to ttf font file.
+# @param ~metadata Change text on a particular metadata (empty string means disabled).
+# @param ~size Font size.
+# @param ~speed Horizontal speed in pixels per second (`0` means no scrolling and update according to `x` and `y` in case they are variable).
+# @param ~x x offset.
+# @param ~y y offset.
+# @params d Text to display.
+def video.add_text.gd =
+  add_text_builder(video.text.gd)
+end
+%endif
+
+%ifdef video.text.sdl
+video.text.available := [("sdl", video.text.sdl), ...video.text.available()]
+
+# Add a text to a stream (SDL implementation).
+# @category Source / Video processing
+# @param ~id Force the value of the source ID.
+# @param ~color Text color (in 0xRRGGBB format).
+# @param ~cycle Cycle text when it reaches left boundary.
+# @param ~font Path to ttf font file.
+# @param ~metadata Change text on a particular metadata (empty string means disabled).
+# @param ~size Font size.
+# @param ~speed Horizontal speed in pixels per second (`0` means no scrolling and update according to `x` and `y` in case they are variable).
+# @param ~x x offset.
+# @param ~y y offset.
+# @params d Text to display.
+def video.add_text.sdl =
+  add_text_builder(video.text.sdl)
+end
+%endif
+
+%ifdef video.text.camlimages
+video.text.available :=
+  [("camlimages", video.text.camlimages), ...video.text.available()]
+
+# Add a text to a stream (camlimages implementation).
+# @category Source / Video processing
+# @param ~id Force the value of the source ID.
+# @param ~color Text color (in 0xRRGGBB format).
+# @param ~cycle Cycle text when it reaches left boundary.
+# @param ~font Path to ttf font file.
+# @param ~metadata Change text on a particular metadata (empty string means disabled).
+# @param ~size Font size.
+# @param ~speed Horizontal speed in pixels per second (`0` means no scrolling and update according to `x` and `y` in case they are variable).
+# @param ~x x offset.
+# @param ~y y offset.
+# @params d Text to display.
+def video.add_text.camlimages =
+  add_text_builder(video.text.camlimages)
+end
+%endif
+
+let settings.video.text =
+  settings.make(
+    description="`video.text` implementation.",
+    fst(list.hd(video.text.available()))
+  )
+
+thread.run(
+  (
+    fun () ->
+      begin
+        text = settings.video.text()
+        if
+          list.assoc.mem(text, video.text.available())
+        then
+          log.important(
+            label="video.text",
+            "Using #{text} implementation"
+          )
+        else
+          log.severe(
+            label="video.text",
+            "Cannot find #{text} implementation for `video.text`, using default #{
+              fst(list.hd(video.text.available()))
+            }"
+          )
+        end
+      end
+  )
+)
+
+# Display a text using the first available operator in: camlimages, SDL, FFmpeg, gd or native.
+# @category Source / Video processing
+# @param ~id Force the value of the source ID.
+# @param ~color Text color (in 0xRRGGBB format).
+# @param ~duration Duration in seconds (`null` means infinite).
+# @param ~font Path to ttf font file.
+# @param ~size Font size.
+# @param text Text to display.
+def replaces video.text(
+  ~id=null,
+  ~color=getter(0xffffff),
+  ~duration=null,
+  ~font=null,
+  ~size=getter(18),
+  text
+) =
+  f =
+    list.assoc(
+      default=snd(list.hd(video.text.available())),
+      settings.video.text(),
+      video.text.available()
+    )
+
+  f(id=id, color=color, duration=duration, font=font, size=size, text)
+end
+
+# Add a text to a stream. Uses the first available operator in: camlimages, SDL,
+# FFmpeg, gd or native.
+# @category Source / Video processing
+# @param ~id Force the value of the source ID.
+# @param ~color Text color (in 0xRRGGBB format).
+# @param ~cycle Cycle text when it reaches left boundary.
+# @param ~font Path to ttf font file.
+# @param ~metadata Change text on a particular metadata (empty string means disabled).
+# @param ~size Font size.
+# @param ~speed Horizontal speed in pixels per second (`0` means no scrolling and update according to `x` and `y` in case they are variable).
+# @param ~x x offset.
+# @param ~y y offset.
+# @param ~on_cycle Function called when text is cycling.
+# @params d Text to display.
+def replaces video.add_text(
+  ~id=null,
+  ~duration=null,
+  ~color=0xffffff,
+  ~cycle=true,
+  ~font=null,
+  ~metadata=null,
+  ~size=18,
+  ~speed=0,
+  ~x=getter(10),
+  ~y=getter(10),
+  ~on_cycle={()},
+  d,
+  s
+) =
+  add_text = add_text_builder(video.text)
+  add_text(
+    id=id,
+    duration=duration,
+    cycle=cycle,
+    font=font,
+    metadata=metadata,
+    size=size,
+    color=color,
+    speed=speed,
+    x=x,
+    y=y,
+    on_cycle=on_cycle,
+    d,
+    s
+  )
+end
+
+# Add subtitle from metadata.
+# @category Source / Video processing
+# @param ~override Metadata where subtitle to display are located.
+# @param ~offset Offset in pixels.
+# @param s Source.
+def video.add_subtitle(
+  ~override="subtitle",
+  ~size=18,
+  ~color=0xffffff,
+  ~offset=20,
+  s
+) =
+  subtitle = ref("")
+  t = video.text(size=size, color=color, subtitle)
+  t = video.bounding_box(t)
+  x = {(video.frame.width() - t.width()) / 2}
+  y = {video.frame.height() - t.height() - offset}
+  t = video.translate(x=x, y=y, t)
+
+  def meta(m) =
+    if list.assoc.mem(override, m) then subtitle := list.assoc(override, m) end
+  end
+
+  s.on_metadata(synchronous=true, meta)
+  let {video = v, ...tracks} = source.tracks(s)
+  let {video = t} = source.tracks(t)
+  let v = track.video.add([v, t])
+  source(tracks.{video = v})
+end
+
+# Display a slideshow (typically of pictures).
+# @category Source / Video processing
+# @param ~cyclic Go to the first picture after the last.
+# @param ~advance Skip to the next file after this amount of time in seconds (negative means never).
+# @param l List of files to display.
+# @method append Append a list of files to the slideshow.
+# @method clear Clear the list of files in the slideshow.
+# @method next Go to next file.
+# @method prev Go to previous file.
+# @method current Currently displayed file.
+def video.slideshow(
+  ~id=null,
+  ~cyclic=getter(true),
+  ~advance=getter(-1.),
+  l=[]
+) =
+  id = string.id.default(default="video.slideshow", id)
+  l = ref(l)
+  n = ref(-1)
+
+  next_source = ref(null)
+
+  def next() =
+    s = next_source()
+    next_source := null
+    s
+  end
+
+  s = source.dynamic(next)
+
+  def current() =
+    list.nth(l(), n())
+  end
+
+  # Set current file to the nth.
+  def set(n') =
+    if
+      0 <= n' and n' < list.length(l()) and n' != n()
+    then
+      n := n'
+      new_source = request.once(request.create(current()))
+      new_source = s.prepare(new_source)
+      next_source := new_source
+    end
+  end
+
+  def next() =
+    log.debug(
+      label=id,
+      "Going to next file"
+    )
+    n' = n() + 1
+    n' =
+      if
+        n' >= list.length(l())
+      then
+        if getter.get(cyclic) then 0 else list.length(l()) - 1 end
+      else
+        n'
+      end
+
+    set(n')
+  end
+
+  def prev() =
+    log.debug(
+      label=id,
+      "Going to previous file"
+    )
+    n' = n() - 1
+    n' =
+      if
+        n' < 0
+      then
+        if getter.get(cyclic) then list.length(l()) - 1 else 0 end
+      else
+        n'
+      end
+
+    set(n')
+  end
+
+  def clear() =
+    l := []
+    n := 0
+  end
+
+  def append(l') =
+    l := list.append(l(), l')
+  end
+
+  set(0)
+  if
+    getter.get(advance) >= 0.
+  then
+    thread.run(delay=getter.get(advance), every=advance, next)
+  end
+
+  s.{
+    append = append,
+    clear = clear,
+    next = next,
+    prev = prev,
+    current = current
+  }
+end
+
+# Generate a video filled with given color.
+# @category Source / Video processing
+# @param color Color (in 0xRRGGBB format).
+def video.color(color) =
+  video.fill(color=color, blank())
+end
+
+# Tile sources
+# @category Source / Video processing
+# @argsof track.video.tile
+# @argsof track.audio.add[!id]
+def video.tile(
+  ~id=null("video.tile"),
+  %argsof(track.audio.add[!id]),
+  %argsof(track.video.tile[!id]),
+  ~weights=[],
+  sources
+) =
+  tracks = list.map(fun (s) -> source.tracks(s), sources)
+  video_tracks = list.map(fun (t) -> t.video, tracks)
+  new_tracks =
+    {video = track.video.tile(%argsof(track.video.tile[!id]), video_tracks)}
+
+  new_tracks =
+    if
+      list.length(tracks) != 0 and null.defined(list.hd(tracks)?.audio)
+    then
+      def mk_audio_track(pos, track) =
+        weight =
+          try
+            list.nth(weights, pos)
+          catch _ do
+            getter(1.)
+          end
+
+        null.get(track?.audio).{weight = weight}
+      end
+
+      audio_tracks = list.mapi(mk_audio_track, tracks)
+      new_tracks.{
+        audio = track.audio.add(%argsof(track.audio.add[!id]), audio_tracks)
+      }
+    else
+      new_tracks
+    end
+
+  source(id=id, new_tracks)
+end
+
+# Plot a floating point value.
+# @category Source / Video processing
+# @param ~color Color of the drawn point (in 0xRRGGBB format).
+# @param ~lines Draw lines connecting plotted points.
+# @param ~min Minimal value of the parameter.
+# @param ~max Maximal value of the parameter.
+# @param ~speed Speed in pixels per second.
+# @param y Value to plot.
+def video.plot(~lines=true, ~min=0., ~max=1., ~speed=100., ~color=0xffffff, y) =
+  width = video.frame.width()
+  height = video.frame.height()
+  s = video.board(width=width * 3, height=height)
+  height = float(s.height())
+  tx = ref(width)
+  ty = ref(0)
+  s' = video.translate(x=tx, y=ty, s)
+
+  # offset of the currently drawn point.
+  x = ref(0)
+  dx = int_of_float(speed * frame.duration())
+
+  def update() =
+    tx := tx() - dx
+    y = int_of_float(((max - y()) / (max - min)) * height)
+    if
+      lines
+    then
+      s.line_to(color=color, x(), y)
+    else
+      s.pixel(x(), y) := color
+    end
+
+    x := x() + dx
+    if
+      x() > width * 2
+    then
+      s.clear_and_copy(x=0 - width)
+      tx := tx() + width
+      x := x() - width
+    end
+  end
+
+  s'.on_frame(synchronous=true, update)
+  s'
+end
+
+let video.canvas = ()
+
+# Create a virtual canvas that can be used to return video position and sizes
+# that are independent of the frame's dimensions.
+# @category Source / Video processing
+# @param ~virtual_width Virtual height, in pixels, of the canvas
+# @param ~actual_size Actual size, in pixels, of the canvas
+# @param ~font_size Font size, in virtual pixels.
+# @method ~px Map a virtual size in pixel to the actual size.
+# @method ~rem Map a fraction of the virtual font size into an actual font size
+# @method ~vh Return a position in percent (as a value between `0.` and `1.`) \
+#             of the canvas height
+# @method ~vw Return a position in percent (as a value between `0.` and `1.`) \
+#             of the canvas width
+def video.canvas.make(~virtual_width, ~actual_size, ~font_size) =
+  virtual_width = float(virtual_width)
+  actual_height = float(actual_size.height)
+  actual_width = float(actual_size.width)
+  ratio = actual_width / virtual_width
+  font_ratio = float(font_size) * ratio
+
+  def px((v:int)) =
+    int_of_float(float(v) * ratio)
+  end
+
+  def vh(v) =
+    int_of_float(v * actual_height)
+  end
+
+  def vw(v) =
+    int_of_float(v * (float(actual_width)))
+  end
+
+  def rem(v) =
+    int_of_float(v * font_ratio)
+  end
+
+  {px = px, rem = rem, vw = vw, vh = vh, ...actual_size}
+end
+
+# Standard video canvas based off a `10k` virtual canvas.
+# @category Source / Video processing
+def video.canvas.virtual_10k =
+  def make(width, height) =
+    video.canvas.make(
+      virtual_width=10000,
+      actual_size={width = width, height = height},
+      font_size=160
+    )
+  end
+
+  {
+    actual_360p = make(640, 360),
+    actual_480p = make(640, 480),
+    actual_720p = make(1280, 720),
+    actual_1080p = make(1920, 1080),
+    actual_1440p = make(2560, 1440),
+    actual_4k = make(3840, 2160),
+    actual_8k = make(7680, 4320)
+  }
+end


### PR DESCRIPTION
## Summary

- Add `-v`/`--version`, `-h`/`--help`, `--stdin-filepath`, and `--dump-ast` options to the CLI
- Fix multi-file handling: space-separated file args now work (previously only the first was used)
- Allow `-c`/`--check` with multiple files without requiring `-w`
- Fix typo: "Writting" → "Writing"
- Update README with per-mode examples
- Add `tests/liq/` with a pre-formatted copy of the liquidsoap stdlib (`src/libs/`)
- Add `.github/workflows/check-formatting.yml` that runs `--check` on all test files on every push and PR

## Test plan

- [x] `node src/cli.js --version` prints the version
- [x] `node src/cli.js --help` prints usage
- [x] `echo 's = sine()' | node src/cli.js --stdin-filepath test.liq` formats from stdin
- [x] `node src/cli.js --dump-ast tests/liq/math.liq` dumps AST as JSON
- [x] `node src/cli.js -c 'tests/liq/**/*.liq'` passes (CI baseline)
- [x] CI workflow triggers on push/PR and passes